### PR TITLE
Detectar cuándo un recurso creado o actualizado es candidato a validación por ser CSV

### DIFF
--- a/ckanext/validate/plugin.py
+++ b/ckanext/validate/plugin.py
@@ -4,6 +4,7 @@ import ckan.plugins.toolkit as toolkit
 from ckanext.validate.actions import action as validate_action
 from ckanext.validate.auth import validation as validate_auth
 from ckanext.validate.blueprints import resource as validate_blueprint
+from ckanext.validate import resource_hooks
 
 
 class ValidatePlugin(plugins.SingletonPlugin):
@@ -11,6 +12,7 @@ class ValidatePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.IBlueprint)
+    plugins.implements(plugins.IResourceController)
 
     # IConfigurer
 
@@ -39,3 +41,19 @@ class ValidatePlugin(plugins.SingletonPlugin):
 
     def get_blueprint(self):
         return [validate_blueprint.resource_validate_blueprint]
+
+    # IResourceController
+
+    def after_resource_create(self, context, resource):
+        resource_hooks.handle_resource_change(
+            context=context,
+            resource_dict=resource,
+            operation="create",
+        )
+
+    def after_resource_update(self, context, resource):
+        resource_hooks.handle_resource_change(
+            context=context,
+            resource_dict=resource,
+            operation="update",
+        )

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -1,0 +1,60 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def is_csv_resource(resource_dict):
+    fmt = (resource_dict.get("format") or "").strip().lower()
+    return fmt == "csv"
+
+
+def is_resource_eligible_for_auto_validation(resource_dict):
+    if not resource_dict:
+        return False
+
+    if not resource_dict.get("id"):
+        return False
+
+    if resource_dict.get("state") == "deleted":
+        return False
+
+    if not is_csv_resource(resource_dict):
+        return False
+
+    return True
+
+
+def handle_resource_change(context, resource_dict, operation):
+    """
+    Step 1 only:
+    detect whether a created/updated resource is a CSV candidate for
+    future automatic validation.
+
+    This function intentionally does not:
+    - patch validation fields
+    - enqueue jobs
+    - run validation
+    """
+    if not is_resource_eligible_for_auto_validation(resource_dict):
+        log.debug(
+            "Skipping auto-validation detection for resource %s on %s "
+            "(format=%r, state=%r, url_type=%r)",
+            resource_dict.get("id"),
+            operation,
+            resource_dict.get("format"),
+            resource_dict.get("state"),
+            resource_dict.get("url_type"),
+        )
+        return False
+
+    log.info(
+        "Auto-validation candidate detected on resource_%s: "
+        "id=%s format=%s url_type=%s url=%s",
+        operation,
+        resource_dict.get("id"),
+        resource_dict.get("format"),
+        resource_dict.get("url_type"),
+        resource_dict.get("url"),
+    )
+
+    return True


### PR DESCRIPTION

Implementa detección automática de recursos CSV en la creación y actualización usando IResourceController y resource_hooks.py. Marca el recurso como "pending" para validación automática en segundo plano.

### Primer paso del flujo de validación automática en segundo plano.

## Qué hace esta PR

- Implementa `IResourceController` en `plugin.py` con los hooks `after_resource_create` y `after_resource_update`, que se ejecutan una vez el recurso ya está persistido (y su `id` disponible).

- Crea `resource_hooks.py` con la lógica de detección: normaliza el `format`, filtra recursos eliminados o sin `id`, y loguea si el recurso es candidato a validación automática.


related #11 punto 1