### PR TITLE
Flujo de validación automática

### DIFF
--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -1,6 +1,9 @@
 import logging
+import ckan.plugins.toolkit as toolkit
 
 log = logging.getLogger(__name__)
+
+_INTERNAL_PENDING_PATCH_FLAG = "_validate_internal_pending_patch"
 
 
 def is_csv_resource(resource_dict):
@@ -24,20 +27,45 @@ def is_resource_eligible_for_auto_validation(resource_dict):
     return True
 
 
+def mark_resource_as_pending(resource_id):
+    toolkit.get_action("resource_patch")(
+        {
+            "ignore_auth": True,
+            _INTERNAL_PENDING_PATCH_FLAG: True,
+        },
+        {
+            "id": resource_id,
+            "validation_status": "pending",
+            "validation_error_count": None,
+            "validation_errors": None,
+        },
+    )
+
+
 def handle_resource_change(context, resource_dict, operation):
     """
-    Step 1 only:
-    detect whether a created/updated resource is a CSV candidate for
-    future automatic validation.
+    Step 2 only:
+    mark eligible CSV resources as pending right after create/update.
 
     This function intentionally does not:
-    - patch validation fields
     - enqueue jobs
     - run validation
+    - modify the UI
     """
+    context = context or {}
+
+    # Avoid re-entering the hook when our own internal resource_patch runs
+    if context.get(_INTERNAL_PENDING_PATCH_FLAG):
+        log.debug(
+            "Skipping pending patch hook re-entry for resource %s on %s",
+            resource_dict.get("id") if resource_dict else None,
+            operation,
+        )
+        return False
+
     if not is_resource_eligible_for_auto_validation(resource_dict):
         log.debug(
-            "Skipping auto-validation detection for resource %s on %s "
+            "Skipping pending status for resource %s on %s "
             "(format=%r, state=%r, url_type=%r)",
             resource_dict.get("id"),
             operation,
@@ -47,11 +75,13 @@ def handle_resource_change(context, resource_dict, operation):
         )
         return False
 
+    mark_resource_as_pending(resource_dict["id"])
+
     log.info(
-        "Auto-validation candidate detected on resource_%s: "
-        "id=%s format=%s url_type=%s url=%s",
-        operation,
+        "Resource %s marked as pending after resource_%s "
+        "(format=%s, url_type=%s, url=%s)",
         resource_dict.get("id"),
+        operation,
         resource_dict.get("format"),
         resource_dict.get("url_type"),
         resource_dict.get("url"),


### PR DESCRIPTION
related #11

Mezclar primero  #12 

Luego de crear o actualizar un recurso, los recursos CSV elegibles se marcan inmediatamente como pending actualizando validation_status, validation_error_count y validation_errors. En este paso todavía no se encola ningún job en background, no se ejecuta la validación y no se incluyen cambios en la UI.

