### PR TITLE
Disparar un job en segundo plano

### DIFF
--- a/ckanext/validate/actions/action.py
+++ b/ckanext/validate/actions/action.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from frictionless import system, Resource
@@ -17,8 +16,7 @@ def resource_validate(context, data_dict):
     :param id: the id of the resource to validate
     :type id: string
 
-    :returns: resource dict with updated validation_status and
-              validation_error_count fields
+    :returns: the resource dict
     :rtype: dict
     """
     resource_id = toolkit.get_or_bust(data_dict, "id")
@@ -88,7 +86,6 @@ def resource_validate(context, data_dict):
 
     error_count = len(error_details)
 
-    # Persist result in dedicated table
     Validation.create(
         resource_id=resource_id,
         status=status,
@@ -96,22 +93,12 @@ def resource_validate(context, data_dict):
         errors=error_details,
     )
 
-    updated_resource = toolkit.get_action("resource_patch")(
-        {"ignore_auth": True},
-        {
-            "id": resource_id,
-            "validation_status": status,
-            "validation_error_count": error_count,
-            "validation_errors": json.dumps(error_details),
-        },
-    )
-
     log.info(
         "Resource %s validation finished: status=%s errors=%d",
         resource_id, status, error_count,
     )
 
-    return updated_resource
+    return resource
 
 
 def resource_validation_show(context, data_dict):

--- a/ckanext/validate/blueprints/resource.py
+++ b/ckanext/validate/blueprints/resource.py
@@ -1,10 +1,11 @@
-import json
 import logging
 
 from flask import Blueprint
 
 from ckan.lib import base
 from ckan.plugins import toolkit
+
+from ckanext.validate.model.validation import Validation
 
 log = logging.getLogger(__name__)
 
@@ -35,32 +36,24 @@ def validate(package_id, resource_id):
     if toolkit.request.method == "POST":
         try:
             context = {"user": toolkit.current_user.name}
-            resource = toolkit.get_action("resource_validate")(
-                context, {"id": resource_id}
-            )
-
-            status = resource.get("validation_status")
-            error_count = resource.get("validation_error_count", 0)
-            if status == "success":
-                toolkit.h.flash_success(toolkit._("Validation completed. No errors found."))
-            elif status == "failure":
-                msg = toolkit._("Validation completed. {} errors found.").format(error_count)
-                toolkit.h.flash_error(msg)
-            else:
-                toolkit.h.flash_success(toolkit._("Validation completed."))
-
+            toolkit.get_action("resource_validate")(context, {"id": resource_id})
         except toolkit.ValidationError as e:
             errors = e.error_dict
         except toolkit.NotAuthorized:
             base.abort(403, toolkit._("Not authorized to validate this resource"))
 
-    validation_errors = []
-    raw = resource.get("validation_errors")
-    if raw:
-        try:
-            validation_errors = json.loads(raw)
-        except (ValueError, TypeError):
-            pass
+        if not errors:
+            record = Validation.get_latest(resource_id)
+            if record and record.status == "success":
+                toolkit.h.flash_success(toolkit._("Validation completed. No errors found."))
+            elif record and record.status == "failure":
+                msg = toolkit._("Validation completed. {} errors found.").format(record.error_count)
+                toolkit.h.flash_error(msg)
+            else:
+                toolkit.h.flash_success(toolkit._("Validation completed."))
+
+    record = Validation.get_latest(resource_id)
+    validation_errors = record.errors if record else []
 
     return base.render(
         "package/resource_validate.html",
@@ -71,6 +64,7 @@ def validate(package_id, resource_id):
             "resource": resource,
             "res": resource,
             "errors": errors,
-            "validation_errors": validation_errors,
+            "validation_errors": validation_errors or [],
+            "validation_error_count": record.error_count if record else 0,
         },
     )

--- a/ckanext/validate/helpers.py
+++ b/ckanext/validate/helpers.py
@@ -1,7 +1,5 @@
-import ckan.lib.jobs as jobs
-
 from ckanext.validate.model.validation import Validation
-from ckanext.validate.resource_hooks import build_validation_job_id
+from ckanext.validate.model.validation_jobs import ValidationJob
 
 
 PENDING_JOB_STATUSES = {"queued", "started", "deferred", "scheduled"}
@@ -16,12 +14,9 @@ def get_resource_validation_job_status(resource_dict):
     if not resource_id:
         return None
 
-    try:
-        job = jobs.job_from_id(build_validation_job_id(resource_id))
-    except KeyError:
-        return None
+    status = ValidationJob.get_latest_job_status_for_resource(resource_id)
 
-    return job.get_status(refresh=True)
+    return status
 
 
 def get_resource_validation_state(resource_dict):

--- a/ckanext/validate/helpers.py
+++ b/ckanext/validate/helpers.py
@@ -1,9 +1,5 @@
 from ckanext.validate.model.validation import Validation
-from ckanext.validate.model.validation_jobs import ValidationJob
-
-
-PENDING_JOB_STATUSES = {"queued", "started", "deferred", "scheduled"}
-ERROR_JOB_STATUSES = {"failed", "stopped", "canceled"}
+from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
 
 
 def get_resource_validation_job_status(resource_dict):
@@ -28,10 +24,10 @@ def get_resource_validation_state(resource_dict):
         return status
 
     job_status = get_resource_validation_job_status(resource_dict)
-    if job_status in PENDING_JOB_STATUSES:
+    if job_status in JobStatus.pending_statuses():
         return "pending"
 
-    if job_status in ERROR_JOB_STATUSES:
+    if job_status in JobStatus.error_statuses():
         return "error"
 
     return None

--- a/ckanext/validate/helpers.py
+++ b/ckanext/validate/helpers.py
@@ -1,0 +1,12 @@
+from ckanext.validate.model.validation import Validation
+
+
+def get_resource_validation_state(resource_dict):
+    if not resource_dict:
+        return None
+
+    status = Validation.get_resource_status(resource_dict.get("id"))
+    if status:
+        return status
+
+    return None

--- a/ckanext/validate/helpers.py
+++ b/ckanext/validate/helpers.py
@@ -1,4 +1,27 @@
+import ckan.lib.jobs as jobs
+
 from ckanext.validate.model.validation import Validation
+from ckanext.validate.resource_hooks import build_validation_job_id
+
+
+PENDING_JOB_STATUSES = {"queued", "started", "deferred", "scheduled"}
+ERROR_JOB_STATUSES = {"failed", "stopped", "canceled"}
+
+
+def get_resource_validation_job_status(resource_dict):
+    if not resource_dict:
+        return None
+
+    resource_id = resource_dict.get("id")
+    if not resource_id:
+        return None
+
+    try:
+        job = jobs.job_from_id(build_validation_job_id(resource_id))
+    except KeyError:
+        return None
+
+    return job.get_status(refresh=True)
 
 
 def get_resource_validation_state(resource_dict):
@@ -8,5 +31,12 @@ def get_resource_validation_state(resource_dict):
     status = Validation.get_resource_status(resource_dict.get("id"))
     if status:
         return status
+
+    job_status = get_resource_validation_job_status(resource_dict)
+    if job_status in PENDING_JOB_STATUSES:
+        return "pending"
+
+    if job_status in ERROR_JOB_STATUSES:
+        return "error"
 
     return None

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -1,0 +1,29 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+
+"""
+Con esta comando, para procesar la cola de validación usar:
+
+ckan -c /etc/ckan/default/ckan.ini jobs worker validate
+
+Y si querés escuchar default y validate a la vez:
+
+ckan -c /etc/ckan/default/ckan.ini jobs worker default validate
+
+https://docs.ckan.org/en/2.11/maintaining/cli.html
+
+"""
+
+def run_resource_validation_job(resource_id):
+    """
+    Step 3 only:
+    background job entrypoint for resource validation.
+
+    The actual validation call will be added in step 4.
+    """
+    log.info(
+        "Validation job dequeued for resource %s",
+        resource_id,
+    )

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import ckan.plugins.toolkit as toolkit
 
@@ -18,17 +19,48 @@ https://docs.ckan.org/en/2.11/maintaining/cli.html
 """
 
 
+def patch_resource_validation_error(resource_id, message):
+    toolkit.get_action("resource_patch")(
+        {"ignore_auth": True},
+        {
+            "id": resource_id,
+            "validation_status": "error",
+            "validation_error_count": None,
+            "validation_errors": json.dumps(
+                [
+                    {
+                        "message": message,
+                    }
+                ]
+            ),
+        },
+    )
+
+
 def run_resource_validation_job(resource_id):
     """
-    Step 4 only:
-    execute validation from the background job by reusing the existing
-    resource_validate action.
+    Step 5:
+    execute validation in the background job and ensure the resource
+    is updated with a final result, including the error case.
     """
     log.info("Starting background validation for resource %s", resource_id)
 
-    toolkit.get_action("resource_validate")(
-        {"ignore_auth": True},
-        {"id": resource_id},
-    )
+    try:
+        toolkit.get_action("resource_validate")(
+            {"ignore_auth": True},
+            {"id": resource_id},
+        )
+        log.info("Finished background validation for resource %s", resource_id)
 
-    log.info("Finished background validation for resource %s", resource_id)
+    except Exception as exc:
+        log.exception(
+            "Background validation failed for resource %s",
+            resource_id,
+        )
+
+        patch_resource_validation_error(
+            resource_id,
+            toolkit._("System error: {0}").format(str(exc)),
+        )
+
+        raise

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -16,6 +16,7 @@ https://docs.ckan.org/en/2.11/maintaining/cli.html
 
 """
 
+
 def run_resource_validation_job(resource_id):
     """
     Step 3 only:

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -1,4 +1,5 @@
 import logging
+import ckan.plugins.toolkit as toolkit
 
 log = logging.getLogger(__name__)
 
@@ -19,12 +20,15 @@ https://docs.ckan.org/en/2.11/maintaining/cli.html
 
 def run_resource_validation_job(resource_id):
     """
-    Step 3 only:
-    background job entrypoint for resource validation.
-
-    The actual validation call will be added in step 4.
+    Step 4 only:
+    execute validation from the background job by reusing the existing
+    resource_validate action.
     """
-    log.info(
-        "Validation job dequeued for resource %s",
-        resource_id,
+    log.info("Starting background validation for resource %s", resource_id)
+
+    toolkit.get_action("resource_validate")(
+        {"ignore_auth": True},
+        {"id": resource_id},
     )
+
+    log.info("Finished background validation for resource %s", resource_id)

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -2,7 +2,7 @@ import logging
 
 import ckan.plugins.toolkit as toolkit
 
-from ckanext.validate.model import Validation
+from ckanext.validate.model.validation_jobs import ValidationJob
 
 log = logging.getLogger(__name__)
 
@@ -28,24 +28,27 @@ def run_resource_validation_job(resource_id):
     site_user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
     context = {"ignore_auth": True, "user": site_user["name"]}
 
+    ValidationJob.create(resource_id=resource_id, status="running")
     try:
         toolkit.get_action("resource_validate")(
             context,
             {"id": resource_id},
         )
         log.info("Finished background validation for resource %s", resource_id)
+        ValidationJob.update(resource_id=resource_id, status="finished")
 
-    except Exception as exc:
+    except ValueError as exc:
+        log.error(
+            "No existing validation job found for resource %s when trying to update status: %s",
+            resource_id,
+            str(exc),
+        )
+        ValidationJob.update(resource_id=resource_id, status="error")
+
+    except Exception:
         log.exception(
             "Background validation failed for resource %s",
             resource_id,
         )
 
-        Validation.create(
-            resource_id=resource_id,
-            status="error",
-            error_count=0,
-            errors=[{"message": toolkit._("System error: {0}").format(str(exc))}],
-        )
-
-        raise
+        ValidationJob.create(resource_id=resource_id, status="error")

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -1,6 +1,8 @@
-import json
 import logging
+
 import ckan.plugins.toolkit as toolkit
+
+from ckanext.validate.model import Validation
 
 log = logging.getLogger(__name__)
 
@@ -15,24 +17,6 @@ https://docs.ckan.org/en/2.11/maintaining/cli.html
 """
 
 
-def patch_resource_validation_error(resource_id, message):
-    toolkit.get_action("resource_patch")(
-        {"ignore_auth": True},
-        {
-            "id": resource_id,
-            "validation_status": "error",
-            "validation_error_count": None,
-            "validation_errors": json.dumps(
-                [
-                    {
-                        "message": message,
-                    }
-                ]
-            ),
-        },
-    )
-
-
 def run_resource_validation_job(resource_id):
     """
     Step 5:
@@ -41,9 +25,12 @@ def run_resource_validation_job(resource_id):
     """
     log.info("Starting background validation for resource %s", resource_id)
 
+    site_user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
+    context = {"ignore_auth": True, "user": site_user["name"]}
+
     try:
         toolkit.get_action("resource_validate")(
-            {"ignore_auth": True},
+            context,
             {"id": resource_id},
         )
         log.info("Finished background validation for resource %s", resource_id)
@@ -54,9 +41,11 @@ def run_resource_validation_job(resource_id):
             resource_id,
         )
 
-        patch_resource_validation_error(
-            resource_id,
-            toolkit._("System error: {0}").format(str(exc)),
+        Validation.create(
+            resource_id=resource_id,
+            status="error",
+            error_count=0,
+            errors=[{"message": toolkit._("System error: {0}").format(str(exc))}],
         )
 
         raise

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -4,13 +4,9 @@ log = logging.getLogger(__name__)
 
 
 """
-Con esta comando, para procesar la cola de validación usar:
+To process the background jobs queue, use the following command:
 
-ckan -c /etc/ckan/default/ckan.ini jobs worker validate
-
-Y si querés escuchar default y validate a la vez:
-
-ckan -c /etc/ckan/default/ckan.ini jobs worker default validate
+ckan -c /etc/ckan/default/ckan.ini jobs worker
 
 https://docs.ckan.org/en/2.11/maintaining/cli.html
 

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -2,7 +2,7 @@ import logging
 
 import ckan.plugins.toolkit as toolkit
 
-from ckanext.validate.model.validation_jobs import ValidationJob
+from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
 
 log = logging.getLogger(__name__)
 
@@ -28,14 +28,14 @@ def run_resource_validation_job(resource_id):
     site_user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
     context = {"ignore_auth": True, "user": site_user["name"]}
 
-    ValidationJob.create(resource_id=resource_id, status="running")
+    ValidationJob.create(resource_id=resource_id, status=JobStatus.RUNNING)
     try:
         toolkit.get_action("resource_validate")(
             context,
             {"id": resource_id},
         )
         log.info("Finished background validation for resource %s", resource_id)
-        ValidationJob.update(resource_id=resource_id, status="finished")
+        ValidationJob.update(resource_id=resource_id, status=JobStatus.FINISHED)
 
     except ValueError as exc:
         log.error(
@@ -43,7 +43,7 @@ def run_resource_validation_job(resource_id):
             resource_id,
             str(exc),
         )
-        ValidationJob.update(resource_id=resource_id, status="error")
+        ValidationJob.update(resource_id=resource_id, status=JobStatus.ERROR)
 
     except Exception:
         log.exception(
@@ -51,4 +51,4 @@ def run_resource_validation_job(resource_id):
             resource_id,
         )
 
-        ValidationJob.create(resource_id=resource_id, status="error")
+        ValidationJob.create(resource_id=resource_id, status=JobStatus.ERROR)

--- a/ckanext/validate/migration/validate/versions/a7bafb6c2b27_add_validation_job_table.py
+++ b/ckanext/validate/migration/validate/versions/a7bafb6c2b27_add_validation_job_table.py
@@ -1,0 +1,46 @@
+"""add validation_job table
+
+Revision ID: a7bafb6c2b27
+Revises: 001_resource_validation
+Create Date: 2026-04-15 14:12:18.022408
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a7bafb6c2b27'
+down_revision = '001_resource_validation'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "resource_validation_jobs",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("resource_id", sa.UnicodeText, nullable=False),
+        sa.Column("status", sa.UnicodeText, nullable=False),
+        sa.Column(
+            "create_timestamp",
+            sa.DateTime,
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "finish_timestamp",
+            sa.DateTime,
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_resource_validation_jobs_resource_id_create_timestamp",
+        "resource_validation_jobs",
+        ["resource_id", "create_timestamp"],
+    )
+
+
+def downgrade():
+    op.drop_index("ix_resource_validation_jobs_resource_id_create_timestamp", "resource_validation_jobs")
+    op.drop_table("resource_validation_jobs")

--- a/ckanext/validate/model/validation.py
+++ b/ckanext/validate/model/validation.py
@@ -50,6 +50,14 @@ class Validation(toolkit.BaseModel, ActiveRecordMixin):
             .first()
         )
 
+    @classmethod
+    def get_resource_status(cls, resource_id):
+        record = cls.get_latest(resource_id)
+        if record:
+            return record.status
+        else:
+            return None
+
     def as_dict(self):
         return {
             "id": self.id,

--- a/ckanext/validate/model/validation_jobs.py
+++ b/ckanext/validate/model/validation_jobs.py
@@ -18,6 +18,7 @@ class JobStatus(str, enum.Enum):
     STARTED = "started"
     DEFERRED = "deferred"
     SCHEDULED = "scheduled"
+    RUNNING = "running"
     # Terminal — success
     FINISHED = "finished"
     # Terminal — failure
@@ -28,7 +29,7 @@ class JobStatus(str, enum.Enum):
 
     @classmethod
     def pending_statuses(cls):
-        return {cls.QUEUED, cls.STARTED, cls.DEFERRED, cls.SCHEDULED}
+        return {cls.QUEUED, cls.STARTED, cls.DEFERRED, cls.SCHEDULED, cls.RUNNING}
 
     @classmethod
     def error_statuses(cls):

--- a/ckanext/validate/model/validation_jobs.py
+++ b/ckanext/validate/model/validation_jobs.py
@@ -1,4 +1,5 @@
 import datetime
+import enum
 import logging
 
 from sqlalchemy import Column, DateTime, Index, Integer, UnicodeText
@@ -9,6 +10,29 @@ from ckan.plugins import toolkit
 
 
 log = logging.getLogger(__name__)
+
+
+class JobStatus(str, enum.Enum):
+    # Pending / in-flight
+    QUEUED = "queued"
+    STARTED = "started"
+    DEFERRED = "deferred"
+    SCHEDULED = "scheduled"
+    # Terminal — success
+    FINISHED = "finished"
+    # Terminal — failure
+    FAILED = "failed"
+    STOPPED = "stopped"
+    CANCELED = "canceled"
+    ERROR = "error"
+
+    @classmethod
+    def pending_statuses(cls):
+        return {cls.QUEUED, cls.STARTED, cls.DEFERRED, cls.SCHEDULED}
+
+    @classmethod
+    def error_statuses(cls):
+        return {cls.FAILED, cls.STOPPED, cls.CANCELED}
 
 
 class ValidationJob(toolkit.BaseModel, ActiveRecordMixin):
@@ -46,7 +70,7 @@ class ValidationJob(toolkit.BaseModel, ActiveRecordMixin):
         record = cls.get_latest_job_for_resource(resource_id)
         if record:
             record.status = status
-            if status in ("finished", "error"):
+            if status in (JobStatus.FINISHED, JobStatus.ERROR):
                 record.finish_timestamp = datetime.datetime.utcnow()
             log.debug("Updating ValidationJob for resource_id %s to status %s", resource_id, status)
             record.commit()

--- a/ckanext/validate/model/validation_jobs.py
+++ b/ckanext/validate/model/validation_jobs.py
@@ -1,0 +1,83 @@
+import datetime
+import logging
+
+from sqlalchemy import Column, DateTime, Index, Integer, UnicodeText
+
+from ckan.model.base import ActiveRecordMixin
+from ckan.model import Session
+from ckan.plugins import toolkit
+
+
+log = logging.getLogger(__name__)
+
+
+class ValidationJob(toolkit.BaseModel, ActiveRecordMixin):
+    """Stores the result of each Frictionless validation run for a resource."""
+
+    __tablename__ = "resource_validation_jobs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    resource_id = Column(UnicodeText, nullable=False)
+    status = Column(UnicodeText, nullable=False)
+    create_timestamp = Column(DateTime, nullable=False, default=datetime.datetime.utcnow)
+    finish_timestamp = Column(DateTime, nullable=True)
+
+    __table_args__ = (
+        Index("ix_resource_validation_jobs_resource_id_create_timestamp", "resource_id", "create_timestamp"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<ValidationJob resource_id={self.resource_id!r} "
+            f"status={self.status!r}>"
+        )
+
+    @classmethod
+    def create(cls, resource_id, status):
+        record = cls(
+            resource_id=resource_id,
+            status=status,
+        )
+        record.save()
+        return record
+
+    @classmethod
+    def update(cls, resource_id, status):
+        record = cls.get_latest_job_for_resource(resource_id)
+        if record:
+            record.status = status
+            if status in ("finished", "error"):
+                record.finish_timestamp = datetime.datetime.utcnow()
+            log.debug("Updating ValidationJob for resource_id %s to status %s", resource_id, status)
+            record.commit()
+            log.info("ValidationJob for resource_id %s updated to status %s", resource_id, status)
+            log.info("ValidationJob record after update: %s", record)
+            return record
+        else:
+            raise ValueError(f"No existing job found for resource_id {resource_id}")
+
+    @classmethod
+    def get_latest_job_for_resource(cls, resource_id):
+        return (
+            Session.query(cls)
+            .filter(cls.resource_id == resource_id)
+            .order_by(cls.create_timestamp.desc())
+            .first()
+        )
+
+    @classmethod
+    def get_latest_job_status_for_resource(cls, resource_id):
+        record = cls.get_latest_job_for_resource(resource_id)
+        if record:
+            return record.status
+        else:
+            return None
+
+    def as_dict(self):
+        return {
+            "id": self.id,
+            "resource_id": self.resource_id,
+            "status": self.status,
+            "created": self.create_timestamp.isoformat() if self.create_timestamp else None,
+            "finished": self.finish_timestamp.isoformat() if self.finish_timestamp else None,
+        }

--- a/ckanext/validate/plugin.py
+++ b/ckanext/validate/plugin.py
@@ -78,4 +78,5 @@ class ValidatePlugin(plugins.SingletonPlugin):
     def get_helpers(self):
         return {
             "get_resource_validation_state": h.get_resource_validation_state,
+            "get_resource_validation_job_status": h.get_resource_validation_job_status,
         }

--- a/ckanext/validate/plugin.py
+++ b/ckanext/validate/plugin.py
@@ -5,6 +5,7 @@ from ckanext.validate.actions import action as validate_action
 from ckanext.validate.auth import validation as validate_auth
 from ckanext.validate.blueprints import resource as validate_blueprint
 from ckanext.validate import resource_hooks
+from ckanext.validate import helpers as h
 
 
 class ValidatePlugin(plugins.SingletonPlugin):
@@ -13,6 +14,7 @@ class ValidatePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IResourceController)
+    plugins.implements(plugins.ITemplateHelpers)
 
     # IConfigurer
 
@@ -72,3 +74,8 @@ class ValidatePlugin(plugins.SingletonPlugin):
             resource_dict=resource,
             operation="update",
         )
+
+    def get_helpers(self):
+        return {
+            "get_resource_validation_state": h.get_resource_validation_state,
+        }

--- a/ckanext/validate/plugin.py
+++ b/ckanext/validate/plugin.py
@@ -13,7 +13,7 @@ class ValidatePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.IBlueprint)
-    plugins.implements(plugins.IResourceController)
+    plugins.implements(plugins.IResourceController, inherit=True)
     plugins.implements(plugins.ITemplateHelpers)
 
     # IConfigurer
@@ -46,26 +46,10 @@ class ValidatePlugin(plugins.SingletonPlugin):
 
     # IResourceController
 
-    def before_resource_create(self, context, resource):
-        pass
-
-    def before_resource_update(self, context, current, resource):
-        pass
-
-    def before_resource_delete(self, context, resource, resources):
-        pass
-
-    def after_resource_delete(self, context, resources):
-        pass
-
-    def before_resource_show(self, resource_dict):
-        pass
-
-    def after_resource_create(self, context, resource):
-        pass
-
     def after_resource_update(self, context, resource):
         resource_hooks.handle_resource_change(resource)
+
+    # ITemplateHelpers
 
     def get_helpers(self):
         return {

--- a/ckanext/validate/plugin.py
+++ b/ckanext/validate/plugin.py
@@ -65,11 +65,7 @@ class ValidatePlugin(plugins.SingletonPlugin):
         pass
 
     def after_resource_update(self, context, resource):
-        resource_hooks.handle_resource_change(
-            context=context,
-            resource_dict=resource,
-            operation="update",
-        )
+        resource_hooks.handle_resource_change(resource)
 
     def get_helpers(self):
         return {

--- a/ckanext/validate/plugin.py
+++ b/ckanext/validate/plugin.py
@@ -62,11 +62,7 @@ class ValidatePlugin(plugins.SingletonPlugin):
         pass
 
     def after_resource_create(self, context, resource):
-        resource_hooks.handle_resource_change(
-            context=context,
-            resource_dict=resource,
-            operation="create",
-        )
+        pass
 
     def after_resource_update(self, context, resource):
         resource_hooks.handle_resource_change(

--- a/ckanext/validate/plugin.py
+++ b/ckanext/validate/plugin.py
@@ -44,6 +44,21 @@ class ValidatePlugin(plugins.SingletonPlugin):
 
     # IResourceController
 
+    def before_resource_create(self, context, resource):
+        pass
+
+    def before_resource_update(self, context, current, resource):
+        pass
+
+    def before_resource_delete(self, context, resource, resources):
+        pass
+
+    def after_resource_delete(self, context, resources):
+        pass
+
+    def before_resource_show(self, resource_dict):
+        pass
+
     def after_resource_create(self, context, resource):
         resource_hooks.handle_resource_change(
             context=context,

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -1,5 +1,7 @@
+
 import logging
 import ckan.plugins.toolkit as toolkit
+from ckanext.validate import jobs
 
 log = logging.getLogger(__name__)
 
@@ -42,19 +44,27 @@ def mark_resource_as_pending(resource_id):
     )
 
 
+def enqueue_resource_validation_job(resource_id):
+    return toolkit.enqueue_job(
+        jobs.run_resource_validation_job,
+        args=[resource_id],
+        title=f"Validate resource {resource_id}",
+        queue="validate",
+    )
+
+
 def handle_resource_change(context, resource_dict, operation):
     """
-    Step 2 only:
-    mark eligible CSV resources as pending right after create/update.
+    Step 3 only:
+    mark eligible CSV resources as pending and enqueue a background job.
 
     This function intentionally does not:
-    - enqueue jobs
     - run validation
+    - patch final validation results
     - modify the UI
     """
     context = context or {}
 
-    # Avoid re-entering the hook when our own internal resource_patch runs
     if context.get(_INTERNAL_PENDING_PATCH_FLAG):
         log.debug(
             "Skipping pending patch hook re-entry for resource %s on %s",
@@ -65,7 +75,7 @@ def handle_resource_change(context, resource_dict, operation):
 
     if not is_resource_eligible_for_auto_validation(resource_dict):
         log.debug(
-            "Skipping pending status for resource %s on %s "
+            "Skipping auto-validation flow for resource %s on %s "
             "(format=%r, state=%r, url_type=%r)",
             resource_dict.get("id"),
             operation,
@@ -75,16 +85,15 @@ def handle_resource_change(context, resource_dict, operation):
         )
         return False
 
-    mark_resource_as_pending(resource_dict["id"])
+    resource_id = resource_dict["id"]
+
+    mark_resource_as_pending(resource_id)
+    enqueue_resource_validation_job(resource_id)
 
     log.info(
-        "Resource %s marked as pending after resource_%s "
-        "(format=%s, url_type=%s, url=%s)",
-        resource_dict.get("id"),
+        "Resource %s marked as pending and validation job enqueued after resource_%s",
+        resource_id,
         operation,
-        resource_dict.get("format"),
-        resource_dict.get("url_type"),
-        resource_dict.get("url"),
     )
 
     return True

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -1,6 +1,9 @@
 import logging
+import ckan.plugins.toolkit as toolkit
 
 log = logging.getLogger(__name__)
+
+_INTERNAL_PENDING_PATCH_FLAG = "_validate_internal_pending_patch"
 
 
 def is_csv_resource(resource_dict):
@@ -24,20 +27,45 @@ def is_resource_eligible_for_auto_validation(resource_dict):
     return True
 
 
+def mark_resource_as_pending(resource_id):
+    toolkit.get_action("resource_patch")(
+        {
+            "ignore_auth": True,
+            _INTERNAL_PENDING_PATCH_FLAG: True,
+        },
+        {
+            "id": resource_id,
+            "validation_status": "pending",
+            "validation_error_count": None,
+            "validation_errors": None,
+        },
+    )
+
+
 def handle_resource_change(context, resource_dict, operation):
     """
-    Step 1 only:
-    detect whether a created/updated resource is a CSV candidate for
-    future automatic validation.
+    Step 2 only:
+    mark eligible CSV resources as pending right after create/update.
 
     This function intentionally does not:
-    - patch validation fields
     - enqueue jobs
     - run validation
+    - modify the UI
     """
+    context = context or {}
+
+    # Avoid re-entering the hook when our own internal resource_patch runs
+    if context.get(_INTERNAL_PENDING_PATCH_FLAG):
+        log.debug(
+            "Skipping pending patch hook re-entry for resource %s on %s",
+            resource_dict.get("id") if resource_dict else None,
+            operation,
+        )
+        return False
+
     if not is_resource_eligible_for_auto_validation(resource_dict):
         log.debug(
-            "Skipping auto-validation detection for resource %s on %s "
+            "Skipping pending status for resource %s on %s "
             "(format=%r, state=%r, url_type=%r)",
             resource_dict.get("id"),
             operation,
@@ -47,11 +75,13 @@ def handle_resource_change(context, resource_dict, operation):
         )
         return False
 
+    mark_resource_as_pending(resource_dict["id"])
+
     log.info(
-        "Auto-validation candidate detected on resource_%s: "
-        "id=%s format=%s url_type=%s url=%s",
-        operation,
+        "Resource %s marked as pending after resource_%s "
+        "(format=%s, url_type=%s, url=%s)",
         resource_dict.get("id"),
+        operation,
         resource_dict.get("format"),
         resource_dict.get("url_type"),
         resource_dict.get("url"),

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -45,13 +45,12 @@ def enqueue_resource_validation_job(resource_id):
         return None
 
 
-def handle_resource_change(context, resource_dict, operation):
+def handle_resource_change(resource_dict):
     if not is_resource_eligible_for_auto_validation(resource_dict):
         log.debug(
             "Skipping auto-validation flow for resource %s on %s "
             "(format=%r, state=%r, url_type=%r)",
             resource_dict.get("id") if resource_dict else None,
-            operation,
             resource_dict.get("format") if resource_dict else None,
             resource_dict.get("state") if resource_dict else None,
             resource_dict.get("url_type") if resource_dict else None,
@@ -64,6 +63,5 @@ def handle_resource_change(context, resource_dict, operation):
     log.info(
         "Validation job enqueued for resource %s after resource_%s",
         resource_id,
-        operation,
     )
     return True

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -49,7 +49,6 @@ def enqueue_resource_validation_job(resource_id):
         jobs.run_resource_validation_job,
         args=[resource_id],
         title=f"Validate resource {resource_id}",
-        queue="validate",
     )
 
 

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -48,7 +48,7 @@ def enqueue_resource_validation_job(resource_id):
 def handle_resource_change(resource_dict):
     if not is_resource_eligible_for_auto_validation(resource_dict):
         log.debug(
-            "Skipping auto-validation flow for resource %s on %s "
+            "Skipping auto-validation flow for resource %s "
             "(format=%r, state=%r, url_type=%r)",
             resource_dict.get("id") if resource_dict else None,
             resource_dict.get("format") if resource_dict else None,
@@ -60,8 +60,5 @@ def handle_resource_change(resource_dict):
     resource_id = resource_dict["id"]
     enqueue_resource_validation_job(resource_id)
 
-    log.info(
-        "Validation job enqueued for resource %s after resource_%s",
-        resource_id,
-    )
+    log.info("Validation job enqueued for resource %s", resource_id)
     return True

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -1,11 +1,10 @@
-
 import logging
+
 import ckan.plugins.toolkit as toolkit
+
 from ckanext.validate import jobs
 
 log = logging.getLogger(__name__)
-
-_INTERNAL_PENDING_PATCH_FLAG = "_validate_internal_pending_patch"
 
 
 def is_csv_resource(resource_dict):
@@ -29,70 +28,42 @@ def is_resource_eligible_for_auto_validation(resource_dict):
     return True
 
 
-def mark_resource_as_pending(resource_id):
-    toolkit.get_action("resource_patch")(
-        {
-            "ignore_auth": True,
-            _INTERNAL_PENDING_PATCH_FLAG: True,
-        },
-        {
-            "id": resource_id,
-            "validation_status": "pending",
-            "validation_error_count": None,
-            "validation_errors": None,
-        },
-    )
+def build_validation_job_id(resource_id):
+    return f"validate-resource-{resource_id}"
 
 
 def enqueue_resource_validation_job(resource_id):
-    return toolkit.enqueue_job(
-        jobs.run_resource_validation_job,
-        args=[resource_id],
-        title=f"Validate resource {resource_id}",
-    )
+    try:
+        return toolkit.enqueue_job(
+            jobs.run_resource_validation_job,
+            args=[resource_id],
+            title=f"Validate resource {resource_id}",
+            rq_kwargs={"job_id": build_validation_job_id(resource_id)},
+        )
+    except Exception:
+        log.debug("Validation job already enqueued for resource %s, skipping", resource_id)
+        return None
 
 
 def handle_resource_change(context, resource_dict, operation):
-    """
-    Step 3 only:
-    mark eligible CSV resources as pending and enqueue a background job.
-
-    This function intentionally does not:
-    - run validation
-    - patch final validation results
-    - modify the UI
-    """
-    context = context or {}
-
-    if context.get(_INTERNAL_PENDING_PATCH_FLAG):
-        log.debug(
-            "Skipping pending patch hook re-entry for resource %s on %s",
-            resource_dict.get("id") if resource_dict else None,
-            operation,
-        )
-        return False
-
     if not is_resource_eligible_for_auto_validation(resource_dict):
         log.debug(
             "Skipping auto-validation flow for resource %s on %s "
             "(format=%r, state=%r, url_type=%r)",
-            resource_dict.get("id"),
+            resource_dict.get("id") if resource_dict else None,
             operation,
-            resource_dict.get("format"),
-            resource_dict.get("state"),
-            resource_dict.get("url_type"),
+            resource_dict.get("format") if resource_dict else None,
+            resource_dict.get("state") if resource_dict else None,
+            resource_dict.get("url_type") if resource_dict else None,
         )
         return False
 
     resource_id = resource_dict["id"]
-
-    mark_resource_as_pending(resource_id)
     enqueue_resource_validation_job(resource_id)
 
     log.info(
-        "Resource %s marked as pending and validation job enqueued after resource_%s",
+        "Validation job enqueued for resource %s after resource_%s",
         resource_id,
         operation,
     )
-
     return True

--- a/ckanext/validate/templates/package/resource_read.html
+++ b/ckanext/validate/templates/package/resource_read.html
@@ -9,13 +9,15 @@
            class="btn btn-default">
           <i class="fa fa-check-circle"></i>
           {{ _('Validate') }}
-          {% set status = res.validation_status %}
+          {% set status = h.get_resource_validation_state(res) %}
           {% if status == 'success' %}
             <span class="validate-badge validate-badge--valid">{{ _('Valid') }}</span>
           {% elif status == 'failure' %}
             <span class="validate-badge validate-badge--invalid">{{ _('Invalid') }}</span>
           {% elif status == 'error' %}
             <span class="validate-badge validate-badge--error">{{ _('Error') }}</span>
+          {% elif status == 'pending' %}
+            <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
           {% endif %}
         </a>
       </li>

--- a/ckanext/validate/templates/package/resource_validate.html
+++ b/ckanext/validate/templates/package/resource_validate.html
@@ -12,17 +12,19 @@
     </div>
   {% endif %}
 
-  {# Current status badge #}
+    {# Current status badge #}
   <div class="module module-narrow module-shallow">
     <div class="module-content">
       <h3>{{ _('Current Status') }}</h3>
-      {% set status = res.validation_status %}
+      {% set status = h.get_resource_validation_state(res) %}
+
       {% if status == 'success' %}
         <span class="validate-badge validate-badge--valid">{{ _('Valid') }}</span>
+
       {% elif status == 'failure' %}
         <span class="validate-badge validate-badge--invalid">{{ _('Invalid') }}</span>
-        {% if res.validation_error_count %}
-          <p class="mt-2"><strong>{{ res.validation_error_count }} {{ _('errors detected') }}</strong></p>
+        {% if validation_error_count %}
+          <p class="mt-2"><strong>{{ validation_error_count }} {{ _('errors detected') }}</strong></p>
         {% endif %}
         {% if validation_errors %}
           <table class="table table-condensed table-bordered mt-2">
@@ -44,16 +46,22 @@
             </tbody>
           </table>
         {% endif %}
+
       {% elif status == 'error' %}
         <span class="validate-badge validate-badge--error">{{ _('Validation Error') }}</span>
         <p class="mt-2">{{ _('An error occurred while running the validator.') }}</p>
+
+      {% elif status == 'pending' %}
+        <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
+        <p class="mt-2">{{ _('Validation is running in the background.') }}</p>
+
       {% else %}
         <span class="validate-badge validate-badge--pending">{{ _('Not validated') }}</span>
       {% endif %}
     </div>
   </div>
 
-  {# Run validation button #}
+{# Run validation button #}
   <form method="post" action="{{ h.url_for('resource_validate.validate', package_id=pkg_dict.name, resource_id=res.id) }}">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}" />
     <button type="submit" class="btn btn-primary">

--- a/ckanext/validate/templates/package/snippets/resource_item.html
+++ b/ckanext/validate/templates/package/snippets/resource_item.html
@@ -3,13 +3,15 @@
 {% block resource_item_title %}
   {{ super() }}
   {% if h.check_access('sysadmin') or h.check_access('package_update', {'id': res.package_id}) %}
-    {% set status = res.validation_status %}
+    {% set status = h.get_resource_validation_state(res) %}
     {% if status == 'success' %}
       <span class="validate-badge validate-badge--valid">{{ _('Valid') }}</span>
     {% elif status == 'failure' %}
       <span class="validate-badge validate-badge--invalid">{{ _('Invalid') }}</span>
     {% elif status == 'error' %}
       <span class="validate-badge validate-badge--error">{{ _('Error') }}</span>
+    {% else %}
+      <span class="validate-badge validate-badge--pending">{{ _('No Validated') }}</span>
     {% endif %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
related #11 

Mezclar primero #13 

Este PR implementa únicamente el paso 3 del flujo de validación automática. Luego de marcar un recurso CSV elegible como pending, se encola un job en background usando CKAN Worker que recibe resource_id como parámetro. En este paso el entrypoint del job es intencionalmente mínimo y todavía no ejecuta la validación; la llamada real a resource_validate se agregará en el paso 4.