### PR TITLE
Manejo robusto de errores en validación automática

### DIFF
--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import ckan.plugins.toolkit as toolkit
 
@@ -18,17 +19,48 @@ https://docs.ckan.org/en/2.11/maintaining/cli.html
 """
 
 
+def patch_resource_validation_error(resource_id, message):
+    toolkit.get_action("resource_patch")(
+        {"ignore_auth": True},
+        {
+            "id": resource_id,
+            "validation_status": "error",
+            "validation_error_count": None,
+            "validation_errors": json.dumps(
+                [
+                    {
+                        "message": message,
+                    }
+                ]
+            ),
+        },
+    )
+
+
 def run_resource_validation_job(resource_id):
     """
-    Step 4 only:
-    execute validation from the background job by reusing the existing
-    resource_validate action.
+    Step 5:
+    execute validation in the background job and ensure the resource
+    is updated with a final result, including the error case.
     """
     log.info("Starting background validation for resource %s", resource_id)
 
-    toolkit.get_action("resource_validate")(
-        {"ignore_auth": True},
-        {"id": resource_id},
-    )
+    try:
+        toolkit.get_action("resource_validate")(
+            {"ignore_auth": True},
+            {"id": resource_id},
+        )
+        log.info("Finished background validation for resource %s", resource_id)
 
-    log.info("Finished background validation for resource %s", resource_id)
+    except Exception as exc:
+        log.exception(
+            "Background validation failed for resource %s",
+            resource_id,
+        )
+
+        patch_resource_validation_error(
+            resource_id,
+            toolkit._("System error: {0}").format(str(exc)),
+        )
+
+        raise


### PR DESCRIPTION
related #11   punto 5

Este PR asegura que, al ejecutar la validación automática en segundo plano, el recurso siempre quede con un estado final. Si la validación falla por un error inesperado en el job, el recurso se actualiza con `validation_status = "error"` y se persiste el mensaje correspondiente. De esta manera, ningún recurso queda indefinidamente en estado `"pending"` y el flujo de validación resulta más robusto y transparente.