### PR TITLE
Mostrar el estado y el reporte en la interfaz

### DIFF
--- a/ckanext/validate/actions/action.py
+++ b/ckanext/validate/actions/action.py
@@ -8,7 +8,10 @@ import ckan.plugins.toolkit as toolkit
 
 from ckanext.validate.model import Validation
 
+
 log = logging.getLogger(__name__)
+
+_VALIDATE_INTERNAL_PATCH_FLAG = "_validate_internal_patch"
 
 
 def resource_validate(context, data_dict):
@@ -96,8 +99,21 @@ def resource_validate(context, data_dict):
         errors=error_details,
     )
 
+    patch_context = {
+        "ignore_auth": True,
+        _VALIDATE_INTERNAL_PATCH_FLAG: True,
+    }
+    if context.get("user"):
+        patch_context["user"] = context["user"]
+
+    log.info(
+        "Calling resource_patch for resource_id=%s patch_context=%r",
+        resource_id,
+        patch_context,
+    )
+
     updated_resource = toolkit.get_action("resource_patch")(
-        {"ignore_auth": True},
+        patch_context,
         {
             "id": resource_id,
             "validation_status": status,

--- a/ckanext/validate/blueprints/resource.py
+++ b/ckanext/validate/blueprints/resource.py
@@ -33,6 +33,13 @@ def validate(package_id, resource_id):
 
     errors = {}
     if toolkit.request.method == "POST":
+        log.info(
+            "Manual validation request package_id=%s resource_id=%s current_user=%r method=%s",
+            package_id,
+            resource_id,
+            getattr(toolkit.current_user, "name", None),
+            toolkit.request.method,
+        )
         try:
             context = {"user": toolkit.current_user.name}
             resource = toolkit.get_action("resource_validate")(

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -1,8 +1,11 @@
+
 import json
 import logging
 import ckan.plugins.toolkit as toolkit
 
 log = logging.getLogger(__name__)
+
+_VALIDATE_INTERNAL_PATCH_FLAG = "_validate_internal_patch"
 
 
 """
@@ -19,35 +22,55 @@ https://docs.ckan.org/en/2.11/maintaining/cli.html
 """
 
 
-def patch_resource_validation_error(resource_id, message):
+def patch_resource_validation_error(resource_id, message, username=None):
+    patch_context = {"ignore_auth": True, _VALIDATE_INTERNAL_PATCH_FLAG: True}
+    if username:
+        patch_context["user"] = username
+
+    log.info(
+        "Patching validation error for resource_id=%s username=%r message=%r",
+        resource_id,
+        username,
+        message,
+    )
+    log.debug("patch_resource_validation_error context=%r", patch_context)
+
     toolkit.get_action("resource_patch")(
-        {"ignore_auth": True},
+        patch_context,
         {
             "id": resource_id,
             "validation_status": "error",
             "validation_error_count": None,
-            "validation_errors": json.dumps(
-                [
-                    {
-                        "message": message,
-                    }
-                ]
-            ),
+            "validation_errors": json.dumps([
+                {
+                    "message": message,
+                }
+            ]),
         },
     )
 
 
-def run_resource_validation_job(resource_id):
+def run_resource_validation_job(resource_id, username=None):
     """
     Step 5:
     execute validation in the background job and ensure the resource
     is updated with a final result, including the error case.
     """
-    log.info("Starting background validation for resource %s", resource_id)
+    log.info("run_resource_validation_job start resource_id=%s username=%r", resource_id, username)
+
+    action_context = {"ignore_auth": True}
+    if username:
+        action_context["user"] = username
+
+    log.info(
+        "Calling resource_validate for resource_id=%s with context=%r",
+        resource_id,
+        action_context,
+    )
 
     try:
         toolkit.get_action("resource_validate")(
-            {"ignore_auth": True},
+            action_context,
             {"id": resource_id},
         )
         log.info("Finished background validation for resource %s", resource_id)
@@ -61,6 +84,7 @@ def run_resource_validation_job(resource_id):
         patch_resource_validation_error(
             resource_id,
             toolkit._("System error: {0}").format(str(exc)),
+            username=username,
         )
 
         raise

--- a/ckanext/validate/plugin.py
+++ b/ckanext/validate/plugin.py
@@ -43,6 +43,9 @@ class ValidatePlugin(plugins.SingletonPlugin):
         return [validate_blueprint.resource_validate_blueprint]
 
     # IResourceController
+        # Added to hook into resource create/update events so CSV resources can be
+        # automatically marked as pending and sent to background validation without
+        # modifying CKAN core actions.
 
     def after_resource_create(self, context, resource):
         resource_hooks.handle_resource_change(
@@ -57,3 +60,18 @@ class ValidatePlugin(plugins.SingletonPlugin):
             resource_dict=resource,
             operation="update",
         )
+
+    def before_resource_show(self, resource_dict):
+        return resource_dict
+
+    def before_resource_create(self, context, resource):
+        return resource
+
+    def before_resource_update(self, context, current, resource):
+        return resource
+
+    def before_resource_delete(self, context, resource, resources):
+        pass
+
+    def after_resource_delete(self, context, resources):
+        pass

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -5,7 +5,7 @@ from ckanext.validate import jobs
 
 log = logging.getLogger(__name__)
 
-_INTERNAL_PENDING_PATCH_FLAG = "_validate_internal_pending_patch"
+_VALIDATE_INTERNAL_PATCH_FLAG = "_validate_internal_patch"
 
 
 def is_csv_resource(resource_dict):
@@ -30,11 +30,13 @@ def is_resource_eligible_for_auto_validation(resource_dict):
 
 
 def mark_resource_as_pending(resource_id):
+    log.info("Marking resource %s as pending", resource_id)
+    patch_context = {
+        "ignore_auth": True,
+        _VALIDATE_INTERNAL_PATCH_FLAG: True,
+    }
     toolkit.get_action("resource_patch")(
-        {
-            "ignore_auth": True,
-            _INTERNAL_PENDING_PATCH_FLAG: True,
-        },
+        patch_context,
         {
             "id": resource_id,
             "validation_status": "pending",
@@ -44,10 +46,11 @@ def mark_resource_as_pending(resource_id):
     )
 
 
-def enqueue_resource_validation_job(resource_id):
+def enqueue_resource_validation_job(resource_id, username=None):
+    log.info("Enqueuing validation job for resource %s user=%r", resource_id, username)
     return toolkit.enqueue_job(
         jobs.run_resource_validation_job,
-        args=[resource_id],
+        args=[resource_id, username],
         title=f"Validate resource {resource_id}",
         queue="validate",
     )
@@ -55,9 +58,6 @@ def enqueue_resource_validation_job(resource_id):
 
 def handle_resource_change(context, resource_dict, operation):
     """
-    Step 3 only:
-    mark eligible CSV resources as pending and enqueue a background job.
-
     This function intentionally does not:
     - run validation
     - patch final validation results
@@ -65,9 +65,18 @@ def handle_resource_change(context, resource_dict, operation):
     """
     context = context or {}
 
-    if context.get(_INTERNAL_PENDING_PATCH_FLAG):
-        log.debug(
-            "Skipping pending patch hook re-entry for resource %s on %s",
+    log.info(
+        "handle_resource_change op=%s resource_id=%s format=%s url_type=%s user=%r",
+        operation,
+        resource_dict.get("id"),
+        resource_dict.get("format"),
+        resource_dict.get("url_type"),
+        context.get("user"),
+    )
+
+    if context.get(_VALIDATE_INTERNAL_PATCH_FLAG):
+        log.info(
+            "Skipping internal validation patch for resource %s on %s",
             resource_dict.get("id") if resource_dict else None,
             operation,
         )
@@ -85,10 +94,14 @@ def handle_resource_change(context, resource_dict, operation):
         )
         return False
 
+    username = context.get("user")
     resource_id = resource_dict["id"]
 
+    log.info("Marking resource %s as pending", resource_id)
     mark_resource_as_pending(resource_id)
-    enqueue_resource_validation_job(resource_id)
+
+    log.info("Enqueuing validation job for resource %s user=%r", resource_id, username)
+    enqueue_resource_validation_job(resource_id, username)
 
     log.info(
         "Resource %s marked as pending and validation job enqueued after resource_%s",

--- a/ckanext/validate/templates/package/resource_read.html
+++ b/ckanext/validate/templates/package/resource_read.html
@@ -10,7 +10,9 @@
           <i class="fa fa-check-circle"></i>
           {{ _('Validate') }}
           {% set status = res.validation_status %}
-          {% if status == 'success' %}
+          {% if status == 'pending' %}
+            <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
+          {% elif status == 'success' %}
             <span class="validate-badge validate-badge--valid">{{ _('Valid') }}</span>
           {% elif status == 'failure' %}
             <span class="validate-badge validate-badge--invalid">{{ _('Invalid') }}</span>

--- a/ckanext/validate/templates/package/resource_validate.html
+++ b/ckanext/validate/templates/package/resource_validate.html
@@ -17,8 +17,13 @@
     <div class="module-content">
       <h3>{{ _('Current Status') }}</h3>
       {% set status = res.validation_status %}
-      {% if status == 'success' %}
+      {% if status == 'pending' %}
+        <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
+        <p class="mt-2">{{ _('Validation is running in the background.') }}</p>
+
+      {% elif status == 'success' %}
         <span class="validate-badge validate-badge--valid">{{ _('Valid') }}</span>
+
       {% elif status == 'failure' %}
         <span class="validate-badge validate-badge--invalid">{{ _('Invalid') }}</span>
         {% if res.validation_error_count %}
@@ -44,9 +49,31 @@
             </tbody>
           </table>
         {% endif %}
+
       {% elif status == 'error' %}
-        <span class="validate-badge validate-badge--error">{{ _('Validation Error') }}</span>
+        <span class="validate-badge validate-badge--error">{{ _('Error') }}</span>
         <p class="mt-2">{{ _('An error occurred while running the validator.') }}</p>
+        {% if validation_errors %}
+          <table class="table table-condensed table-bordered mt-2">
+            <thead>
+              <tr>
+                <th>{{ _('Row') }}</th>
+                <th>{{ _('Field') }}</th>
+                <th>{{ _('Message') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for err in validation_errors %}
+              <tr>
+                <td>{{ err.row or '-' }}</td>
+                <td>{{ err.field or '-' }}</td>
+                <td>{{ err.message }}</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        {% endif %}
+
       {% else %}
         <span class="validate-badge validate-badge--pending">{{ _('Not validated') }}</span>
       {% endif %}

--- a/ckanext/validate/templates/package/snippets/resource_item.html
+++ b/ckanext/validate/templates/package/snippets/resource_item.html
@@ -4,7 +4,9 @@
   {{ super() }}
   {% if h.check_access('sysadmin') or h.check_access('package_update', {'id': res.package_id}) %}
     {% set status = res.validation_status %}
-    {% if status == 'success' %}
+    {% if status == 'pending' %}
+      <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
+    {% elif status == 'success' %}
       <span class="validate-badge validate-badge--valid">{{ _('Valid') }}</span>
     {% elif status == 'failure' %}
       <span class="validate-badge validate-badge--invalid">{{ _('Invalid') }}</span>


### PR DESCRIPTION
related #11  punto 6

Este PR implementa el paso 6 del flujo de validación automática ajustando la interfaz para mostrar de forma consistente todos los estados de validación. La lista de recursos, la página del recurso y la vista de validación ahora contemplan pending, success, failure y error, y la vista de detalle muestra el reporte final o los mensajes de error persistidos cuando existen.


## Resumen
**primer commit (https://github.com/okfn/ckanext-validate/pull/17/commits/9dbb93986ed999fa33b0103346a28afc16d091bc)**
Este PR completa el soporte visual para la validación automática de recursos CSV.

Se agrega soporte para todos los estados de validación en la interfaz:

- `pending`
- `success`
- `failure`
- `error`

## Qué cambió 
**(segundo commit: https://github.com/okfn/ckanext-validate/pull/17/commits/e9d04fc566a24041f2d5a4e1a328c004250381c3)**

### Backend
- Se agrega `_VALIDATE_INTERNAL_PATCH_FLAG` para evitar loops internos de validación durante llamados a `resource_patch`.
- Se preserva el usuario actual en los patches internos y en los jobs de validación.
- Se agregan logs puntuales para:
  - inicio del job
  - disparo de validación manual
  - patches internos
  - reentradas internas salteadas del hook
- Se agregan en `plugin.py` los métodos requeridos de `IResourceController`.

### Frontend
- Se agrega el badge `Pending` en:
  - lista de recursos
  - página del recurso
  - vista de validación
- Se mejora la vista de detalle de validación para mostrar:
  - estado pendiente
  - estado de error
  - tabla de errores tanto para `failure` como para `error`





