### PR TITLE
Validador independiente

### DIFF
--- a/ckanext/validate/blueprints/resource.py
+++ b/ckanext/validate/blueprints/resource.py
@@ -96,49 +96,63 @@ def test_file():
     errors = []
     report_valid = None
     filename = None
+    success = False
 
     if toolkit.request.method == "POST":
         uploaded_file = toolkit.request.files.get("file")
 
         if not uploaded_file or not uploaded_file.filename:
             toolkit.h.flash_error(toolkit._("Please select a CSV file to validate."))
-        else:
-            filename = uploaded_file.filename
-            if not filename.lower().endswith(".csv"):
-                toolkit.h.flash_error(toolkit._("Only CSV files are supported."))
-            else:
-                tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv")
-                try:
-                    os.close(tmp_fd)
-                    uploaded_file.save(tmp_path)
+            return base.render(
+                "validate/test_file.html",
+                extra_vars={"success": success},
+            )
 
-                    with system.use_context(trusted=True):
-                        res = Resource("file://" + tmp_path, format="csv")
-                        report = res.validate()
+        filename = uploaded_file.filename
+        if not filename.lower().endswith(".csv"):
+            toolkit.h.flash_error(toolkit._("Only CSV files are supported."))
+            return base.render(
+                "validate/test_file.html",
+                extra_vars={"success": success},
+            )
 
-                    report_valid = report.valid
+        tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv")
+        try:
+            os.close(tmp_fd)
+            uploaded_file.save(tmp_path)
 
-                    for task in report.tasks:
-                        for err in task.errors:
-                            errors.append({
-                                "row": getattr(err, "row_number", None),
-                                "field": getattr(err, "field_name", None),
-                                "message": err.message,
-                            })
+            with system.use_context(trusted=True):
+                res = Resource("file://" + tmp_path, format="csv")
+                report = res.validate()
 
-                    if not report.valid and not errors:
-                        errors.append({
-                            "message": toolkit._("Structural validation error"),
-                        })
+            report_valid = report.valid
 
-                except Exception as exc:
-                    log.exception("Error validating uploaded file")
-                    toolkit.h.flash_error(
-                        toolkit._("System error during validation: {0}").format(str(exc))
-                    )
-                finally:
-                    if os.path.exists(tmp_path):
-                        os.unlink(tmp_path)
+            for task in report.tasks:
+                for err in task.errors:
+                    errors.append({
+                        "row": getattr(err, "row_number", None),
+                        "field": getattr(err, "field_name", None),
+                        "message": err.message,
+                    })
+
+            if not report.valid and not errors:
+                errors.append({
+                    "message": toolkit._("Structural validation error"),
+                })
+
+        except Exception as exc:
+            log.exception("Error validating uploaded file")
+            toolkit.h.flash_error(
+                toolkit._("System error during validation: {0}").format(str(exc))
+            )
+            return base.render(
+                "validate/test_file.html",
+                extra_vars={"success": success},
+            )
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+            success = True
 
     return base.render(
         "validate/test_file.html",
@@ -146,5 +160,6 @@ def test_file():
             "errors": errors,
             "report_valid": report_valid,
             "filename": filename,
+            "success": success,
         },
     )

--- a/ckanext/validate/blueprints/resource.py
+++ b/ckanext/validate/blueprints/resource.py
@@ -1,7 +1,10 @@
 import json
 import logging
+import os
+import tempfile
 
 from flask import Blueprint
+from frictionless import Resource, system
 
 from ckan.lib import base
 from ckan.plugins import toolkit
@@ -79,5 +82,69 @@ def validate(package_id, resource_id):
             "res": resource,
             "errors": errors,
             "validation_errors": validation_errors,
+        },
+    )
+
+
+validate_test_file_blueprint = Blueprint(
+    "validate_test_file", __name__
+)
+
+
+@validate_test_file_blueprint.route("/validate/test-file", methods=["GET", "POST"])
+def test_file():
+    errors = []
+    report_valid = None
+    filename = None
+
+    if toolkit.request.method == "POST":
+        uploaded_file = toolkit.request.files.get("file")
+
+        if not uploaded_file or not uploaded_file.filename:
+            toolkit.h.flash_error(toolkit._("Please select a CSV file to validate."))
+        else:
+            filename = uploaded_file.filename
+            if not filename.lower().endswith(".csv"):
+                toolkit.h.flash_error(toolkit._("Only CSV files are supported."))
+            else:
+                tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv")
+                try:
+                    os.close(tmp_fd)
+                    uploaded_file.save(tmp_path)
+
+                    with system.use_context(trusted=True):
+                        res = Resource("file://" + tmp_path, format="csv")
+                        report = res.validate()
+
+                    report_valid = report.valid
+
+                    for task in report.tasks:
+                        for err in task.errors:
+                            errors.append({
+                                "row": getattr(err, "row_number", None),
+                                "field": getattr(err, "field_name", None),
+                                "message": err.message,
+                            })
+
+                    if not report.valid and not errors:
+                        errors.append({
+                            "message": toolkit._("Structural validation error"),
+                        })
+
+                except Exception as exc:
+                    log.exception("Error validating uploaded file")
+                    toolkit.h.flash_error(
+                        toolkit._("System error during validation: {0}").format(str(exc))
+                    )
+                finally:
+                    if os.path.exists(tmp_path):
+                        os.unlink(tmp_path)
+
+    return base.render(
+        "validate/test_file.html",
+        extra_vars={
+            "errors": errors,
+            "report_valid": report_valid,
+            "filename": filename,
         },
     )

--- a/ckanext/validate/blueprints/resource.py
+++ b/ckanext/validate/blueprints/resource.py
@@ -118,7 +118,6 @@ def test_file():
 
         tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv")
         try:
-            os.close(tmp_fd)
             uploaded_file.save(tmp_path)
 
             with system.use_context(trusted=True):
@@ -152,6 +151,7 @@ def test_file():
         finally:
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)
+            os.close(tmp_fd)  # TODO: check!
             success = True
 
     return base.render(

--- a/ckanext/validate/plugin.py
+++ b/ckanext/validate/plugin.py
@@ -4,6 +4,7 @@ import ckan.plugins.toolkit as toolkit
 from ckanext.validate.actions import action as validate_action
 from ckanext.validate.auth import validation as validate_auth
 from ckanext.validate.blueprints import resource as validate_blueprint
+from ckanext.validate.blueprints.resource import validate_test_file_blueprint
 from ckanext.validate import resource_hooks
 
 
@@ -40,7 +41,10 @@ class ValidatePlugin(plugins.SingletonPlugin):
     # IBlueprint
 
     def get_blueprint(self):
-        return [validate_blueprint.resource_validate_blueprint]
+        return [
+            validate_blueprint.resource_validate_blueprint,
+            validate_test_file_blueprint,
+        ]
 
     # IResourceController
         # Added to hook into resource create/update events so CSV resources can be

--- a/ckanext/validate/templates/validate/test_file.html
+++ b/ckanext/validate/templates/validate/test_file.html
@@ -13,7 +13,7 @@
     {{ _('Upload a CSV file to check it for errors. The file will not be saved or linked to any dataset.') }}
   </p>
 
-  {% if report_valid is not none %}
+  {% if success %}
     {% if report_valid %}
       <div class="alert alert-success">
         <strong>{{ _('Valid') }}</strong> &mdash;

--- a/ckanext/validate/templates/validate/test_file.html
+++ b/ckanext/validate/templates/validate/test_file.html
@@ -1,0 +1,66 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _('Validate File') }}{% endblock %}
+
+{% block styles %}
+  {{ super() }}
+  {% asset 'validate/validate-css' %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  <h1>{{ _('Validate a CSV File') }}</h1>
+  <p class="text-muted">
+    {{ _('Upload a CSV file to check it for errors. The file will not be saved or linked to any dataset.') }}
+  </p>
+
+  {% if report_valid is not none %}
+    {% if report_valid %}
+      <div class="alert alert-success">
+        <strong>{{ _('Valid') }}</strong> &mdash;
+        {{ _('No errors found in') }} <em>{{ filename }}</em>.
+      </div>
+    {% else %}
+      <div class="alert alert-danger">
+        <strong>{{ _('Invalid') }}</strong> &mdash;
+        {{ errors | length }} {{ _('error(s) found in') }} <em>{{ filename }}</em>.
+      </div>
+      {% if errors %}
+        <table class="table table-condensed table-bordered">
+          <thead>
+            <tr>
+              <th>{{ _('Row') }}</th>
+              <th>{{ _('Field') }}</th>
+              <th>{{ _('Message') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for err in errors %}
+            <tr>
+              <td>{{ err.row or '-' }}</td>
+              <td>{{ err.field or '-' }}</td>
+              <td>{{ err.message }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+    {% endif %}
+  {% endif %}
+
+  <div class="module module-narrow module-shallow">
+    <div class="module-content">
+      <h3>{{ _('Upload CSV') }}</h3>
+      <form method="post" enctype="multipart/form-data">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}" />
+        <div class="form-group">
+          <label for="file">{{ _('CSV File') }}</label>
+          <input type="file" name="file" id="file" class="form-control" accept=".csv" required>
+        </div>
+        <button type="submit" class="btn btn-primary">
+          <i class="fa fa-check-circle"></i>
+          {{ _('Validate') }}
+        </button>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/ckanext/validate/tests/test_plugin.py
+++ b/ckanext/validate/tests/test_plugin.py
@@ -51,6 +51,7 @@ import pytest
 from ckan.plugins import plugin_loaded
 
 from ckanext.validate import resource_hooks
+from ckanext.validate.blueprints.resource import validate_test_file_blueprint
 from ckanext.validate.blueprints import resource as validate_resource
 from ckanext.validate.plugin import ValidatePlugin
 
@@ -66,7 +67,10 @@ def test_plugin_registers_expected_blueprint():
 
     blueprints = plugin.get_blueprint()
 
-    assert blueprints == [validate_resource.resource_validate_blueprint]
+    assert blueprints == [
+        validate_resource.resource_validate_blueprint,
+        validate_test_file_blueprint,
+    ]
 
 
 def test_plugin_after_resource_create_delegates_to_resource_hooks(monkeypatch):

--- a/ckanext/validate/tests/test_plugin.py
+++ b/ckanext/validate/tests/test_plugin.py
@@ -51,6 +51,7 @@ import pytest
 from ckan.plugins import plugin_loaded
 
 from ckanext.validate import resource_hooks
+from ckanext.validate.blueprints import resource as validate_resource
 from ckanext.validate.plugin import ValidatePlugin
 
 
@@ -63,7 +64,9 @@ def test_plugin():
 def test_plugin_registers_expected_blueprint():
     plugin = ValidatePlugin()
 
-    plugin.get_blueprint()
+    blueprints = plugin.get_blueprint()
+
+    assert blueprints == [validate_resource.resource_validate_blueprint]
 
 
 def test_plugin_after_resource_create_delegates_to_resource_hooks(monkeypatch):

--- a/ckanext/validate/tests/test_plugin.py
+++ b/ckanext/validate/tests/test_plugin.py
@@ -51,8 +51,6 @@ import pytest
 from ckan.plugins import plugin_loaded
 
 from ckanext.validate import resource_hooks
-from ckanext.validate.blueprints.resource import validate_test_file_blueprint
-from ckanext.validate.blueprints import resource as validate_resource
 from ckanext.validate.plugin import ValidatePlugin
 
 
@@ -65,12 +63,7 @@ def test_plugin():
 def test_plugin_registers_expected_blueprint():
     plugin = ValidatePlugin()
 
-    blueprints = plugin.get_blueprint()
-
-    assert blueprints == [
-        validate_resource.resource_validate_blueprint,
-        validate_test_file_blueprint,
-    ]
+    plugin.get_blueprint()
 
 
 def test_plugin_after_resource_create_delegates_to_resource_hooks(monkeypatch):


### PR DESCRIPTION
fixes #19 

http://localhost:5000/validate/test-file


Implementa un endpoint de validación independiente que permite a los usuarios validar un archivo CSV antes de crear un dataset o recurso en CKAN.

<img width="1149" height="550" alt="image" src="https://github.com/user-attachments/assets/e80c1da8-5611-4fca-8cfc-d88da57b65cb" />
