### PR TITLE
485 update frictionless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/frictionlessdata/frictionless-py.git@be08dcf491781a565d230f47e08707e703292d85
+frictionless==5.19.0


### PR DESCRIPTION
related https://github.com/okfn/ckan-bcie/issues/485#issuecomment-4236627034

Esto actualiza frictiones aun asi no corrige el warning, aparentemente el problema viene del request.

si chardet está instalado en el entorno, requests intenta usarlo aunque venga por otra dependencia, y emite RequestsDependencyWarning cuando la versión no entra en su rango soportado


**Resolver el warning en el entorno CKAN con una de estas dos opciones:**

1.  Eliminar chardet del entorno si ninguna dependencia lo necesita directamente, para que requests use charset-normalizer. Los issues recientes explican que requests usa chardet cuando está importable; si no está, usa charset-normalizer.

2. **Temporal**: fijar chardet<6 en la imagen o constraints globales del proyecto, no en ckanext-validate, solo para silenciar el warning mientras Requests no soporte esas versiones nuevas. Los propios issues describen que el warning aparece con chardet 6/7 y sugieren volver a una versión compatible para evitarlo. ([link](https://github.com/psf/requests/issues/7284))
