### PR TITLE
update frictionless dependency to version 5.19.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/frictionlessdata/frictionless-py.git@be08dcf491781a565d230f47e08707e703292d85
+frictionless==5.19.0


### PR DESCRIPTION
related https://github.com/okfn/ckanext-validate/pull/18

Reaciendo PR 