### PR TITLE
Validador independiente

### DIFF
--- a/ckanext/validate/blueprints/resource.py
+++ b/ckanext/validate/blueprints/resource.py
@@ -1,6 +1,9 @@
 import logging
+import os
+import tempfile
 
 from flask import Blueprint
+from frictionless import Resource, system
 
 from ckan.lib import base
 from ckan.plugins import toolkit
@@ -11,6 +14,10 @@ log = logging.getLogger(__name__)
 
 resource_validate_blueprint = Blueprint(
     "resource_validate", __name__, url_prefix="/dataset"
+)
+
+validate_test_file_blueprint = Blueprint(
+    "validate_test_file", __name__, url_prefix="/validate"
 )
 
 
@@ -66,5 +73,79 @@ def validate(package_id, resource_id):
             "errors": errors,
             "validation_errors": validation_errors or [],
             "validation_error_count": record.error_count if record else 0,
+        },
+    )
+
+
+@validate_test_file_blueprint.route("/test-file", methods=["GET", "POST"])
+def test_file():
+    errors = []
+    report_valid = None
+    filename = None
+    success = False
+
+    if toolkit.request.method == "POST":
+        uploaded_file = toolkit.request.files.get("file")
+
+        if not uploaded_file or not uploaded_file.filename:
+            toolkit.h.flash_error(toolkit._("Please select a CSV file to validate."))
+            return base.render(
+                "validate/test_file.html",
+                extra_vars={"success": success},
+            )
+
+        filename = uploaded_file.filename
+        if not filename.lower().endswith(".csv"):
+            toolkit.h.flash_error(toolkit._("Only CSV files are supported."))
+            return base.render(
+                "validate/test_file.html",
+                extra_vars={"success": success},
+            )
+
+        tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv")
+        try:
+            uploaded_file.save(tmp_path)
+
+            with system.use_context(trusted=True):
+                res = Resource("file://" + tmp_path, format="csv")
+                report = res.validate()
+
+            report_valid = report.valid
+
+            for task in report.tasks:
+                for err in task.errors:
+                    errors.append({
+                        "row": getattr(err, "row_number", None),
+                        "field": getattr(err, "field_name", None),
+                        "message": err.message,
+                    })
+
+            if not report.valid and not errors:
+                errors.append({
+                    "message": toolkit._("Structural validation error"),
+                })
+
+        except Exception as exc:
+            log.exception("Error validating uploaded file")
+            toolkit.h.flash_error(
+                toolkit._("System error during validation: {0}").format(str(exc))
+            )
+            return base.render(
+                "validate/test_file.html",
+                extra_vars={"success": success},
+            )
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+            os.close(tmp_fd)  # TODO: check!
+            success = True
+
+    return base.render(
+        "validate/test_file.html",
+        extra_vars={
+            "errors": errors,
+            "report_valid": report_valid,
+            "filename": filename,
+            "success": success,
         },
     )

--- a/ckanext/validate/plugin.py
+++ b/ckanext/validate/plugin.py
@@ -3,7 +3,7 @@ import ckan.plugins.toolkit as toolkit
 
 from ckanext.validate.actions import action as validate_action
 from ckanext.validate.auth import validation as validate_auth
-from ckanext.validate.blueprints import resource as validate_blueprint
+from ckanext.validate.blueprints import resource
 from ckanext.validate import resource_hooks
 from ckanext.validate import helpers as h
 
@@ -42,7 +42,10 @@ class ValidatePlugin(plugins.SingletonPlugin):
     # IBlueprint
 
     def get_blueprint(self):
-        return [validate_blueprint.resource_validate_blueprint]
+        return [
+            resource.resource_validate_blueprint,
+            resource.validate_test_file_blueprint,
+        ]
 
     # IResourceController
 

--- a/ckanext/validate/templates/validate/test_file.html
+++ b/ckanext/validate/templates/validate/test_file.html
@@ -1,0 +1,66 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _('Validate File') }}{% endblock %}
+
+{% block styles %}
+  {{ super() }}
+  {% asset 'validate/validate-css' %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  <h1>{{ _('Validate a CSV File') }}</h1>
+  <p class="text-muted">
+    {{ _('Upload a CSV file to check it for errors. The file will not be saved or linked to any dataset.') }}
+  </p>
+
+  {% if success %}
+    {% if report_valid %}
+      <div class="alert alert-success">
+        <strong>{{ _('Valid') }}</strong> &mdash;
+        {{ _('No errors found in') }} <em>{{ filename }}</em>.
+      </div>
+    {% else %}
+      <div class="alert alert-danger">
+        <strong>{{ _('Invalid') }}</strong> &mdash;
+        {{ errors | length }} {{ _('error(s) found in') }} <em>{{ filename }}</em>.
+      </div>
+      {% if errors %}
+        <table class="table table-condensed table-bordered">
+          <thead>
+            <tr>
+              <th>{{ _('Row') }}</th>
+              <th>{{ _('Field') }}</th>
+              <th>{{ _('Message') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for err in errors %}
+            <tr>
+              <td>{{ err.row or '-' }}</td>
+              <td>{{ err.field or '-' }}</td>
+              <td>{{ err.message }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+    {% endif %}
+  {% endif %}
+
+  <div class="module module-narrow module-shallow">
+    <div class="module-content">
+      <h3>{{ _('Upload CSV') }}</h3>
+      <form method="post" enctype="multipart/form-data">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}" />
+        <div class="form-group">
+          <label for="file">{{ _('CSV File') }}</label>
+          <input type="file" name="file" id="file" class="form-control" accept=".csv" required>
+        </div>
+        <button type="submit" class="btn btn-primary">
+          <i class="fa fa-check-circle"></i>
+          {{ _('Validate') }}
+        </button>
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Se rehízo el PR https://github.com/okfn/ckanext-validate/pull/21

fixes https://github.com/okfn/ckanext-validate/issues/19

http://localhost:5000/validate/test-file

Implementa un endpoint de validación independiente que permite a los usuarios validar un archivo CSV antes de crear un dataset o recurso en CKAN.