### PR TITLE
Modificando como se muestran los estados

### DIFF
--- a/ckanext/validate/actions/action.py
+++ b/ckanext/validate/actions/action.py
@@ -62,7 +62,6 @@ def resource_validate(context, data_dict):
         "Frictionless validation completed for resource %s: valid=%s",
         resource_id, report.valid,
     )
-    log.debug("Validation report for resource %s: %s", resource_id, report.to_descriptor())
 
     status = "success" if report.valid else "failure"
 

--- a/ckanext/validate/assets/css/validate.css
+++ b/ckanext/validate/assets/css/validate.css
@@ -29,3 +29,14 @@
   background-color: #6c757d;
   color: #fff;
 }
+
+.validate-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.validate-badge i {
+  margin-right: 4px;
+}
+

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -16,7 +16,7 @@ https://docs.ckan.org/en/2.11/maintaining/cli.html
 """
 
 
-def run_resource_validation_job(resource_id, job_id=None):
+def run_resource_validation_job(resource_id, job_id):
     """
     Execute validation in the background job and ensure the resource
     is updated with a final result, including the error case.
@@ -30,22 +30,11 @@ def run_resource_validation_job(resource_id, job_id=None):
     site_user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
     context = {"ignore_auth": True, "user": site_user["name"]}
 
-    if job_id is not None:
-        try:
-            ValidationJob.update_by_id(job_id, JobStatus.RUNNING)
-        except ValueError:
-            # Fallback por si el registro no existiera por datos viejos o ejecución manual
-            current_job = ValidationJob.create(
-                resource_id=resource_id,
-                status=JobStatus.RUNNING,
-            )
-            job_id = current_job.id
-    else:
-        current_job = ValidationJob.create(
-            resource_id=resource_id,
-            status=JobStatus.RUNNING,
-        )
-        job_id = current_job.id
+    try:
+        ValidationJob.update_by_id(job_id, JobStatus.RUNNING)
+    except ValueError:
+        log.error("Job record with id %s not found, creating new job record for resource %s", job_id, resource_id)
+        return
 
     try:
         toolkit.get_action("resource_validate")(
@@ -65,7 +54,4 @@ def run_resource_validation_job(resource_id, job_id=None):
             resource_id,
             job_id,
         )
-        try:
-            ValidationJob.update_by_id(job_id, JobStatus.ERROR)
-        except ValueError:
-            ValidationJob.create(resource_id=resource_id, status=JobStatus.ERROR)
+        ValidationJob.update_by_id(job_id, JobStatus.ERROR)

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -13,14 +13,12 @@ To process the background jobs queue, use the following command:
 ckan -c /etc/ckan/default/ckan.ini jobs worker
 
 https://docs.ckan.org/en/2.11/maintaining/cli.html
-
 """
 
 
 def run_resource_validation_job(resource_id):
     """
-    Step 5:
-    execute validation in the background job and ensure the resource
+    Execute validation in the background job and ensure the resource
     is updated with a final result, including the error case.
     """
     log.info("Starting background validation for resource %s", resource_id)
@@ -28,7 +26,12 @@ def run_resource_validation_job(resource_id):
     site_user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
     context = {"ignore_auth": True, "user": site_user["name"]}
 
-    ValidationJob.create(resource_id=resource_id, status=JobStatus.RUNNING)
+    try:
+        ValidationJob.update(resource_id=resource_id, status=JobStatus.RUNNING)
+    except ValueError:
+        # Fallback por si el registro no existiera por datos viejos o ejecución manual
+        ValidationJob.create(resource_id=resource_id, status=JobStatus.RUNNING)
+
     try:
         toolkit.get_action("resource_validate")(
             context,
@@ -37,18 +40,12 @@ def run_resource_validation_job(resource_id):
         log.info("Finished background validation for resource %s", resource_id)
         ValidationJob.update(resource_id=resource_id, status=JobStatus.FINISHED)
 
-    except ValueError as exc:
-        log.error(
-            "No existing validation job found for resource %s when trying to update status: %s",
-            resource_id,
-            str(exc),
-        )
-        ValidationJob.update(resource_id=resource_id, status=JobStatus.ERROR)
-
     except Exception:
         log.exception(
             "Background validation failed for resource %s",
             resource_id,
         )
-
-        ValidationJob.create(resource_id=resource_id, status=JobStatus.ERROR)
+        try:
+            ValidationJob.update(resource_id=resource_id, status=JobStatus.ERROR)
+        except ValueError:
+            ValidationJob.create(resource_id=resource_id, status=JobStatus.ERROR)

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -21,44 +21,51 @@ def run_resource_validation_job(resource_id, job_id=None):
     Execute validation in the background job and ensure the resource
     is updated with a final result, including the error case.
     """
-    log.info("Starting background validation for resource %s", resource_id)
+    log.info(
+        "Starting background validation for resource %s (job_id=%s)",
+        resource_id,
+        job_id,
+    )
 
     site_user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
     context = {"ignore_auth": True, "user": site_user["name"]}
 
-    current_job = ValidationJob.get_latest_job_for_resource(resource_id)
-    # si el job existe finalizarlos/cancelarlos/terminarlos
-
-    if current_job and current_job.status in JobStatus.pending_statuses():
-        log.debug(
-            "Existing pending job found for resource %s (status=%s), marking as stopped",
-            resource_id,
-            current_job.status,
+    if job_id is not None:
+        try:
+            ValidationJob.update_by_id(job_id, JobStatus.RUNNING)
+        except ValueError:
+            # Fallback por si el registro no existiera por datos viejos o ejecución manual
+            current_job = ValidationJob.create(
+                resource_id=resource_id,
+                status=JobStatus.RUNNING,
+            )
+            job_id = current_job.id
+    else:
+        current_job = ValidationJob.create(
+            resource_id=resource_id,
+            status=JobStatus.RUNNING,
         )
-        ValidationJob.update(resource_id=resource_id, status=JobStatus.STOPPED)
- 
-    try:
-        ValidationJob.update(resource_id=resource_id, status=JobStatus.RUNNING)
-    except ValueError:
-        # Fallback por si el registro no existiera por datos viejos o ejecución manual
-        ValidationJob.create(resource_id=resource_id, status=JobStatus.RUNNING)
+        job_id = current_job.id
 
     try:
         toolkit.get_action("resource_validate")(
             context,
             {"id": resource_id},
         )
-        log.info("Finished background validation for resource %s", resource_id)
-        # TODO: Mejorar esto para actualizar el job específico en vez de asumir que el último es el correcto
-        ValidationJob.update(resource_id=resource_id, status=JobStatus.FINISHED)
+        log.info(
+            "Finished background validation for resource %s (job_id=%s)",
+            resource_id,
+            job_id,
+        )
+        ValidationJob.update_by_id(job_id, JobStatus.FINISHED)
 
     except Exception:
         log.exception(
-            "Background validation failed for resource %s",
+            "Background validation failed for resource %s (job_id=%s)",
             resource_id,
+            job_id,
         )
         try:
-            ValidationJob.update(resource_id=resource_id, status=JobStatus.ERROR)
-        # TODO: Mejorar esto para actualizar el job específico en vez de asumir que el último es el correcto
+            ValidationJob.update_by_id(job_id, JobStatus.ERROR)
         except ValueError:
             ValidationJob.create(resource_id=resource_id, status=JobStatus.ERROR)

--- a/ckanext/validate/jobs.py
+++ b/ckanext/validate/jobs.py
@@ -16,7 +16,7 @@ https://docs.ckan.org/en/2.11/maintaining/cli.html
 """
 
 
-def run_resource_validation_job(resource_id):
+def run_resource_validation_job(resource_id, job_id=None):
     """
     Execute validation in the background job and ensure the resource
     is updated with a final result, including the error case.
@@ -26,6 +26,17 @@ def run_resource_validation_job(resource_id):
     site_user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
     context = {"ignore_auth": True, "user": site_user["name"]}
 
+    current_job = ValidationJob.get_latest_job_for_resource(resource_id)
+    # si el job existe finalizarlos/cancelarlos/terminarlos
+
+    if current_job and current_job.status in JobStatus.pending_statuses():
+        log.debug(
+            "Existing pending job found for resource %s (status=%s), marking as stopped",
+            resource_id,
+            current_job.status,
+        )
+        ValidationJob.update(resource_id=resource_id, status=JobStatus.STOPPED)
+ 
     try:
         ValidationJob.update(resource_id=resource_id, status=JobStatus.RUNNING)
     except ValueError:
@@ -38,6 +49,7 @@ def run_resource_validation_job(resource_id):
             {"id": resource_id},
         )
         log.info("Finished background validation for resource %s", resource_id)
+        # TODO: Mejorar esto para actualizar el job específico en vez de asumir que el último es el correcto
         ValidationJob.update(resource_id=resource_id, status=JobStatus.FINISHED)
 
     except Exception:
@@ -47,5 +59,6 @@ def run_resource_validation_job(resource_id):
         )
         try:
             ValidationJob.update(resource_id=resource_id, status=JobStatus.ERROR)
+        # TODO: Mejorar esto para actualizar el job específico en vez de asumir que el último es el correcto
         except ValueError:
             ValidationJob.create(resource_id=resource_id, status=JobStatus.ERROR)

--- a/ckanext/validate/model/validation_jobs.py
+++ b/ckanext/validate/model/validation_jobs.py
@@ -35,6 +35,16 @@ class JobStatus(str, enum.Enum):
     def error_statuses(cls):
         return {cls.FAILED, cls.STOPPED, cls.CANCELED, cls.ERROR}
 
+    @classmethod
+    def terminal_statuses(cls):
+        return {
+            cls.FINISHED,
+            cls.FAILED,
+            cls.STOPPED,
+            cls.CANCELED,
+            cls.ERROR,
+        }
+
 
 class ValidationJob(toolkit.BaseModel, ActiveRecordMixin):
     """Stores the status of each background validation job for a resource."""
@@ -61,23 +71,40 @@ class ValidationJob(toolkit.BaseModel, ActiveRecordMixin):
     def create(cls, resource_id, status):
         record = cls(
             resource_id=resource_id,
-            status=status,
+            status=status.value if isinstance(status, JobStatus) else status,
         )
         record.save()
         return record
 
     @classmethod
+    def get(cls, job_id):
+        return Session.query(cls).filter(cls.id == job_id).first()
+
+    @classmethod
     def update(cls, resource_id, status):
         record = cls.get_latest_job_for_resource(resource_id)
-        if record:
-            record.status = status
-            if status in (JobStatus.FINISHED, JobStatus.ERROR):
-                record.finish_timestamp = datetime.datetime.utcnow()
-            record.commit()
-            log.info("ValidationJob for resource_id %s updated to status %s", resource_id, status)
-            return record
-        else:
+        if not record:
             raise ValueError(f"No existing job found for resource_id {resource_id}")
+        return cls.update_by_id(record.id, status)
+
+    @classmethod
+    def update_by_id(cls, job_id, status):
+        record = cls.get(job_id)
+        if not record:
+            raise ValueError(f"No existing job found for job_id {job_id}")
+
+        record.status = status.value if isinstance(status, JobStatus) else status
+        if status in JobStatus.terminal_statuses():
+            record.finish_timestamp = datetime.datetime.utcnow()
+
+        record.commit()
+        log.info(
+            "ValidationJob id=%s for resource_id=%s updated to status=%s",
+            record.id,
+            record.resource_id,
+            status,
+        )
+        return record
 
     @classmethod
     def get_latest_job_for_resource(cls, resource_id):

--- a/ckanext/validate/model/validation_jobs.py
+++ b/ckanext/validate/model/validation_jobs.py
@@ -33,7 +33,7 @@ class JobStatus(str, enum.Enum):
 
     @classmethod
     def error_statuses(cls):
-        return {cls.FAILED, cls.STOPPED, cls.CANCELED}
+        return {cls.FAILED, cls.STOPPED, cls.CANCELED, cls.ERROR}
 
 
 class ValidationJob(toolkit.BaseModel, ActiveRecordMixin):

--- a/ckanext/validate/model/validation_jobs.py
+++ b/ckanext/validate/model/validation_jobs.py
@@ -29,7 +29,11 @@ class JobStatus(str, enum.Enum):
 
     @classmethod
     def pending_statuses(cls):
-        return {cls.QUEUED, cls.STARTED, cls.DEFERRED, cls.SCHEDULED, cls.RUNNING}
+        return {cls.QUEUED, cls.STARTED, cls.DEFERRED, cls.SCHEDULED}
+
+    @classmethod
+    def running_statuses(cls):
+        return {cls.RUNNING}
 
     @classmethod
     def error_statuses(cls):

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -50,8 +50,8 @@ def enqueue_resource_validation_job(resource_id):
             title=f"Validate resource {resource_id}",
         )
     except Exception:
-        # Mantener el estado queued si el job ya estaba en cola con el mismo job_id
-        log.debug("Validation job already enqueued for resource %s, skipping", resource_id)
+        log.exception("Failed to enqueue validation job for resource %s", resource_id)
+        ValidationJob.update_by_id(job.id, JobStatus.ERROR)
         return None
 
 

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -3,6 +3,7 @@ import logging
 import ckan.plugins.toolkit as toolkit
 
 from ckanext.validate import jobs
+from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +34,19 @@ def build_validation_job_id(resource_id):
 
 
 def enqueue_resource_validation_job(resource_id):
+    latest_status = ValidationJob.get_latest_job_status_for_resource(resource_id)
+
+    if latest_status in JobStatus.pending_statuses():
+        log.debug(
+            "Validation job already pending for resource %s (status=%s), skipping enqueue",
+            resource_id,
+            latest_status,
+        )
+        return None
+
+    # Crear el registro ANTES de encolar para que la UI pueda mostrar Pending
+    ValidationJob.create(resource_id=resource_id, status=JobStatus.QUEUED)
+
     try:
         return toolkit.enqueue_job(
             jobs.run_resource_validation_job,
@@ -41,6 +55,7 @@ def enqueue_resource_validation_job(resource_id):
             rq_kwargs={"job_id": build_validation_job_id(resource_id)},
         )
     except Exception:
+        # Mantener el estado queued si el job ya estaba en cola con el mismo job_id
         log.debug("Validation job already enqueued for resource %s, skipping", resource_id)
         return None
 

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -32,6 +32,8 @@ def is_resource_eligible_for_auto_validation(resource_dict):
 def enqueue_resource_validation_job(resource_id):
     latest_status = ValidationJob.get_latest_job_status_for_resource(resource_id)
 
+    # TODO: handel running jobs scenario
+
     if latest_status in JobStatus.pending_statuses():
         log.debug(
             "Validation job already pending for resource %s (status=%s), skipping enqueue",

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -29,10 +29,6 @@ def is_resource_eligible_for_auto_validation(resource_dict):
     return True
 
 
-def build_validation_job_id(resource_id):
-    return f"validate-resource-{resource_id}"
-
-
 def enqueue_resource_validation_job(resource_id):
     latest_status = ValidationJob.get_latest_job_status_for_resource(resource_id)
 
@@ -45,14 +41,13 @@ def enqueue_resource_validation_job(resource_id):
         return None
 
     # Crear el registro ANTES de encolar para que la UI pueda mostrar Pending
-    ValidationJob.create(resource_id=resource_id, status=JobStatus.QUEUED)
+    job = ValidationJob.create(resource_id=resource_id, status=JobStatus.QUEUED)
 
     try:
         return toolkit.enqueue_job(
             jobs.run_resource_validation_job,
-            args=[resource_id],
+            args=[resource_id, job.id],
             title=f"Validate resource {resource_id}",
-            rq_kwargs={"job_id": build_validation_job_id(resource_id)},
         )
     except Exception:
         # Mantener el estado queued si el job ya estaba en cola con el mismo job_id

--- a/ckanext/validate/templates/package/resource_read.html
+++ b/ckanext/validate/templates/package/resource_read.html
@@ -17,7 +17,10 @@
           {% elif status == 'error' %}
             <span class="validate-badge validate-badge--error">{{ _('Error') }}</span>
           {% elif status == 'pending' %}
-            <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
+            <span class="validate-badge validate-badge--pending">
+              <i class="fa fa-spinner fa-spin"></i>
+              {{ _('Pending') }}
+            </span>
           {% else %}
             <span class="validate-badge validate-badge--pending">{{ _('Not validated') }}</span>
           {% endif %}

--- a/ckanext/validate/templates/package/resource_read.html
+++ b/ckanext/validate/templates/package/resource_read.html
@@ -18,6 +18,8 @@
             <span class="validate-badge validate-badge--error">{{ _('Error') }}</span>
           {% elif status == 'pending' %}
             <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
+          {% else %}
+            <span class="validate-badge validate-badge--pending">{{ _('Not validated') }}</span>
           {% endif %}
         </a>
       </li>

--- a/ckanext/validate/templates/package/resource_validate.html
+++ b/ckanext/validate/templates/package/resource_validate.html
@@ -18,7 +18,10 @@
       <h3>{{ _('Current Status') }}</h3>
       {% set status = h.get_resource_validation_state(res) %}
       {% if status == 'pending' %}
-        <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
+        <span class="validate-badge validate-badge--pending">
+          <i class="fa fa-spinner fa-spin"></i>
+          {{ _('Pending') }}
+        </span>
         <p class="mt-2">{{ _('Validation is running in the background.') }}</p>
 
       {% elif status == 'success' %}

--- a/ckanext/validate/templates/package/snippets/resource_item.html
+++ b/ckanext/validate/templates/package/snippets/resource_item.html
@@ -11,7 +11,10 @@
     {% elif status == 'error' %}
       <span class="validate-badge validate-badge--error">{{ _('Error') }}</span>
     {% elif status == 'pending' %}
-      <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
+      <span class="validate-badge validate-badge--pending">
+        <i class="fa fa-spinner fa-spin"></i>
+        {{ _('Pending') }}
+      </span>
     {% else %}
       <span class="validate-badge validate-badge--pending">{{ _('Not validated') }}</span>
     {% endif %}

--- a/ckanext/validate/templates/package/snippets/resource_item.html
+++ b/ckanext/validate/templates/package/snippets/resource_item.html
@@ -12,6 +12,8 @@
       <span class="validate-badge validate-badge--error">{{ _('Error') }}</span>
     {% elif status == 'pending' %}
       <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
+    {% else %}
+      <span class="validate-badge validate-badge--pending">{{ _('Not validated') }}</span>
     {% endif %}
   {% endif %}
 {% endblock %}

--- a/ckanext/validate/templates/scheming/display_snippets/validation_status.html
+++ b/ckanext/validate/templates/scheming/display_snippets/validation_status.html
@@ -8,7 +8,10 @@
   {% elif status == 'error' %}
     <span class="validate-badge validate-badge--error">{{ _('Error') }}</span>
   {% elif status == 'pending' %}
-    <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
+    <span class="validate-badge validate-badge--pending">
+      <i class="fa fa-spinner fa-spin"></i>
+      {{ _('Pending') }}
+    </span>
   {% else %}
     <span class="validate-badge validate-badge--pending">{{ _('Not validated') }}</span>
   {% endif %}

--- a/ckanext/validate/templates/scheming/display_snippets/validation_status.html
+++ b/ckanext/validate/templates/scheming/display_snippets/validation_status.html
@@ -1,14 +1,14 @@
 {# Mostrar badges solo a usuarios logueados y que sean sysadmin o admin #}
 {% if h.check_access('sysadmin') or h.check_access('package_update', {'id': data['id']}) %}
-  {% if data[field.field_name] %}
-    {% set status = data[field.field_name] %}
-    {% if status == 'success' %}
-      <span class="validate-badge validate-badge--valid">{{ _('Valid') }}</span>
-    {% elif status == 'failure' %}
-      <span class="validate-badge validate-badge--invalid">{{ _('Invalid') }}</span>
-    {% elif status == 'error' %}
-      <span class="validate-badge validate-badge--error">{{ _('Error') }}</span>
-    {% endif %}
+  {% set status = h.get_resource_validation_state(data) %}
+  {% if status == 'success' %}
+    <span class="validate-badge validate-badge--valid">{{ _('Valid') }}</span>
+  {% elif status == 'failure' %}
+    <span class="validate-badge validate-badge--invalid">{{ _('Invalid') }}</span>
+  {% elif status == 'error' %}
+    <span class="validate-badge validate-badge--error">{{ _('Error') }}</span>
+  {% elif status == 'pending' %}
+    <span class="validate-badge validate-badge--pending">{{ _('Pending') }}</span>
   {% else %}
     <span class="validate-badge validate-badge--pending">{{ _('Not validated') }}</span>
   {% endif %}

--- a/ckanext/validate/tests/test_jobs.py
+++ b/ckanext/validate/tests/test_jobs.py
@@ -85,16 +85,15 @@ def test_run_resource_validation_job_marks_error_when_validation_fails(monkeypat
     ]
 
 
-def test_run_resource_validation_job_creates_running_when_job_record_does_not_exist(monkeypatch):
-    captured = {}
+def test_run_resource_validation_job_returns_early_when_job_record_does_not_exist(monkeypatch):
+    resource_validate_called = []
     state_calls = []
 
     def fake_get_site_user(context, data_dict):
         return {"name": "site-user"}
 
     def fake_resource_validate(context, data_dict):
-        captured["context"] = context
-        captured["data_dict"] = data_dict
+        resource_validate_called.append(True)
         return {"id": "res-3"}
 
     def fake_get_action(name):
@@ -109,22 +108,12 @@ def test_run_resource_validation_job_creates_running_when_job_record_does_not_ex
         if status == JobStatus.RUNNING:
             raise ValueError("No existing job found for job_id")
 
-    def fake_create(resource_id, status):
-        state_calls.append(("create", resource_id, status))
-        return SimpleNamespace(id=999)
-
     monkeypatch.setattr(jobs.toolkit, "get_action", fake_get_action)
     monkeypatch.setattr(jobs.ValidationJob, "update_by_id", fake_update_by_id)
-    monkeypatch.setattr(jobs.ValidationJob, "create", fake_create)
 
     jobs.run_resource_validation_job("res-3", job_id=321)
 
-    assert captured == {
-        "context": {"ignore_auth": True, "user": "site-user"},
-        "data_dict": {"id": "res-3"},
-    }
+    assert resource_validate_called == []
     assert state_calls == [
         ("update_by_id", 321, JobStatus.RUNNING),
-        ("create", "res-3", JobStatus.RUNNING),
-        ("update_by_id", 999, JobStatus.FINISHED),
     ]

--- a/ckanext/validate/tests/test_jobs.py
+++ b/ckanext/validate/tests/test_jobs.py
@@ -42,7 +42,7 @@ def test_run_resource_validation_job_calls_resource_validate_with_site_user(monk
         "data_dict": {"id": "res-1"},
     }
     assert state_calls == [
-        ("create", "res-1", JobStatus.RUNNING),
+        ("update", "res-1", JobStatus.RUNNING),
         ("update", "res-1", JobStatus.FINISHED),
     ]
 
@@ -78,6 +78,51 @@ def test_run_resource_validation_job_marks_error_when_validation_fails(monkeypat
     jobs.run_resource_validation_job("res-2")
 
     assert state_calls == [
-        ("create", "res-2", JobStatus.RUNNING),
-        ("create", "res-2", JobStatus.ERROR),
+        ("update", "res-2", JobStatus.RUNNING),
+        ("update", "res-2", JobStatus.ERROR),
+    ]
+
+
+def test_run_resource_validation_job_creates_running_when_job_record_does_not_exist(monkeypatch):
+    captured = {}
+    state_calls = []
+
+    def fake_get_site_user(context, data_dict):
+        return {"name": "site-user"}
+
+    def fake_resource_validate(context, data_dict):
+        captured["context"] = context
+        captured["data_dict"] = data_dict
+        return {"id": "res-3"}
+
+    def fake_get_action(name):
+        if name == "get_site_user":
+            return fake_get_site_user
+        if name == "resource_validate":
+            return fake_resource_validate
+        raise AssertionError(f"Unexpected action requested: {name}")
+
+    def fake_update(resource_id, status):
+        state_calls.append(("update", resource_id, status))
+        if status == JobStatus.RUNNING:
+            raise ValueError("No existing job found")
+
+    monkeypatch.setattr(jobs.toolkit, "get_action", fake_get_action)
+    monkeypatch.setattr(
+        jobs.ValidationJob,
+        "create",
+        lambda resource_id, status: state_calls.append(("create", resource_id, status)),
+    )
+    monkeypatch.setattr(jobs.ValidationJob, "update", fake_update)
+
+    jobs.run_resource_validation_job("res-3")
+
+    assert captured == {
+        "context": {"ignore_auth": True, "user": "site-user"},
+        "data_dict": {"id": "res-3"},
+    }
+    assert state_calls == [
+        ("update", "res-3", JobStatus.RUNNING),
+        ("create", "res-3", JobStatus.RUNNING),
+        ("update", "res-3", JobStatus.FINISHED),
     ]

--- a/ckanext/validate/tests/test_jobs.py
+++ b/ckanext/validate/tests/test_jobs.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from ckanext.validate import jobs
 from ckanext.validate.model.validation_jobs import JobStatus
 
@@ -27,23 +29,23 @@ def test_run_resource_validation_job_calls_resource_validate_with_site_user(monk
     monkeypatch.setattr(
         jobs.ValidationJob,
         "create",
-        lambda resource_id, status: state_calls.append(("create", resource_id, status)),
+        lambda resource_id, status: SimpleNamespace(id=123),
     )
     monkeypatch.setattr(
         jobs.ValidationJob,
-        "update",
-        lambda resource_id, status: state_calls.append(("update", resource_id, status)),
+        "update_by_id",
+        lambda job_id, status: state_calls.append(("update_by_id", job_id, status)),
     )
 
-    jobs.run_resource_validation_job("res-1")
+    jobs.run_resource_validation_job("res-1", job_id=123)
 
     assert captured == {
         "context": {"ignore_auth": True, "user": "site-user"},
         "data_dict": {"id": "res-1"},
     }
     assert state_calls == [
-        ("update", "res-1", JobStatus.RUNNING),
-        ("update", "res-1", JobStatus.FINISHED),
+        ("update_by_id", 123, JobStatus.RUNNING),
+        ("update_by_id", 123, JobStatus.FINISHED),
     ]
 
 
@@ -67,19 +69,19 @@ def test_run_resource_validation_job_marks_error_when_validation_fails(monkeypat
     monkeypatch.setattr(
         jobs.ValidationJob,
         "create",
-        lambda resource_id, status: state_calls.append(("create", resource_id, status)),
+        lambda resource_id, status: SimpleNamespace(id=456),
     )
     monkeypatch.setattr(
         jobs.ValidationJob,
-        "update",
-        lambda resource_id, status: state_calls.append(("update", resource_id, status)),
+        "update_by_id",
+        lambda job_id, status: state_calls.append(("update_by_id", job_id, status)),
     )
 
-    jobs.run_resource_validation_job("res-2")
+    jobs.run_resource_validation_job("res-2", job_id=456)
 
     assert state_calls == [
-        ("update", "res-2", JobStatus.RUNNING),
-        ("update", "res-2", JobStatus.ERROR),
+        ("update_by_id", 456, JobStatus.RUNNING),
+        ("update_by_id", 456, JobStatus.ERROR),
     ]
 
 
@@ -102,27 +104,27 @@ def test_run_resource_validation_job_creates_running_when_job_record_does_not_ex
             return fake_resource_validate
         raise AssertionError(f"Unexpected action requested: {name}")
 
-    def fake_update(resource_id, status):
-        state_calls.append(("update", resource_id, status))
+    def fake_update_by_id(job_id, status):
+        state_calls.append(("update_by_id", job_id, status))
         if status == JobStatus.RUNNING:
-            raise ValueError("No existing job found")
+            raise ValueError("No existing job found for job_id")
+
+    def fake_create(resource_id, status):
+        state_calls.append(("create", resource_id, status))
+        return SimpleNamespace(id=999)
 
     monkeypatch.setattr(jobs.toolkit, "get_action", fake_get_action)
-    monkeypatch.setattr(
-        jobs.ValidationJob,
-        "create",
-        lambda resource_id, status: state_calls.append(("create", resource_id, status)),
-    )
-    monkeypatch.setattr(jobs.ValidationJob, "update", fake_update)
+    monkeypatch.setattr(jobs.ValidationJob, "update_by_id", fake_update_by_id)
+    monkeypatch.setattr(jobs.ValidationJob, "create", fake_create)
 
-    jobs.run_resource_validation_job("res-3")
+    jobs.run_resource_validation_job("res-3", job_id=321)
 
     assert captured == {
         "context": {"ignore_auth": True, "user": "site-user"},
         "data_dict": {"id": "res-3"},
     }
     assert state_calls == [
-        ("update", "res-3", JobStatus.RUNNING),
+        ("update_by_id", 321, JobStatus.RUNNING),
         ("create", "res-3", JobStatus.RUNNING),
-        ("update", "res-3", JobStatus.FINISHED),
+        ("update_by_id", 999, JobStatus.FINISHED),
     ]

--- a/ckanext/validate/tests/test_resource_hooks.py
+++ b/ckanext/validate/tests/test_resource_hooks.py
@@ -1,13 +1,16 @@
+from types import SimpleNamespace
+
 from ckanext.validate import jobs
 from ckanext.validate import resource_hooks
+from ckanext.validate.model.validation_jobs import JobStatus
 
 
-def test_build_validation_job_id_is_deterministic():
-    assert resource_hooks.build_validation_job_id("res-1") == "validate-resource-res-1"
-
-
-def test_enqueue_resource_validation_job_uses_deterministic_job_id(monkeypatch):
+def test_enqueue_resource_validation_job_creates_db_job_and_enqueues_with_job_id_arg(monkeypatch):
     captured = {}
+
+    def fake_create(resource_id, status):
+        captured["created"] = (resource_id, status)
+        return SimpleNamespace(id=1)
 
     def fake_enqueue_job(fn, args=None, kwargs=None, title=None, queue="default", rq_kwargs=None):
         captured["fn"] = fn
@@ -16,30 +19,28 @@ def test_enqueue_resource_validation_job_uses_deterministic_job_id(monkeypatch):
         captured["title"] = title
         captured["queue"] = queue
         captured["rq_kwargs"] = rq_kwargs
-        return "job-123"
+        return "queued-job"
 
+    monkeypatch.setattr(
+        resource_hooks.ValidationJob,
+        "get_latest_job_status_for_resource",
+        lambda resource_id: None,
+    )
+    monkeypatch.setattr(resource_hooks.ValidationJob, "create", fake_create)
     monkeypatch.setattr(resource_hooks.toolkit, "enqueue_job", fake_enqueue_job)
 
     result = resource_hooks.enqueue_resource_validation_job("res-1")
 
-    assert result == "job-123"
+    assert result == "queued-job"
     assert captured == {
+        "created": ("res-1", JobStatus.QUEUED),
         "fn": jobs.run_resource_validation_job,
-        "args": ["res-1"],
+        "args": ["res-1", 1],
         "kwargs": None,
         "title": "Validate resource res-1",
         "queue": "default",
-        "rq_kwargs": {"job_id": "validate-resource-res-1"},
+        "rq_kwargs": None,
     }
-
-
-def test_enqueue_resource_validation_job_returns_none_when_enqueue_fails(monkeypatch):
-    def fake_enqueue_job(fn, args=None, kwargs=None, title=None, queue="default", rq_kwargs=None):
-        raise RuntimeError("already queued")
-
-    monkeypatch.setattr(resource_hooks.toolkit, "enqueue_job", fake_enqueue_job)
-
-    assert resource_hooks.enqueue_resource_validation_job("res-1") is None
 
 
 def test_handle_resource_change_enqueues_job_for_eligible_resource(monkeypatch):
@@ -83,7 +84,11 @@ def test_handle_resource_change_skips_non_csv(monkeypatch):
     def fake_enqueue_resource_validation_job(resource_id):
         called["enqueue"] = True
 
-    monkeypatch.setattr(resource_hooks, "enqueue_resource_validation_job", fake_enqueue_resource_validation_job)
+    monkeypatch.setattr(
+        resource_hooks,
+        "enqueue_resource_validation_job",
+        fake_enqueue_resource_validation_job,
+    )
 
     result = resource_hooks.handle_resource_change(resource)
 
@@ -105,9 +110,41 @@ def test_handle_resource_change_skips_deleted_resource(monkeypatch):
     def fake_enqueue_resource_validation_job(resource_id):
         called["enqueue"] = True
 
-    monkeypatch.setattr(resource_hooks, "enqueue_resource_validation_job", fake_enqueue_resource_validation_job)
+    monkeypatch.setattr(
+        resource_hooks,
+        "enqueue_resource_validation_job",
+        fake_enqueue_resource_validation_job,
+    )
 
     result = resource_hooks.handle_resource_change(resource)
 
     assert result is False
     assert called == {"enqueue": False}
+
+
+def test_enqueue_resource_validation_job_returns_none_when_enqueue_fails(monkeypatch):
+    def fake_enqueue_job(fn, args=None, kwargs=None, title=None, queue="default", rq_kwargs=None):
+        raise RuntimeError("already queued")
+
+    monkeypatch.setattr(
+        resource_hooks.ValidationJob,
+        "get_latest_job_status_for_resource",
+        lambda resource_id: None,
+    )
+    monkeypatch.setattr(
+        resource_hooks.ValidationJob,
+        "create",
+        lambda resource_id, status: SimpleNamespace(id=1),
+    )
+
+    updated = {}
+
+    def fake_update_by_id(job_id, status):
+        updated["job_id"] = job_id
+        updated["status"] = status
+
+    monkeypatch.setattr(resource_hooks.ValidationJob, "update_by_id", fake_update_by_id)
+    monkeypatch.setattr(resource_hooks.toolkit, "enqueue_job", fake_enqueue_job)
+
+    assert resource_hooks.enqueue_resource_validation_job("res-1") is None
+    assert updated == {"job_id": 1, "status": JobStatus.ERROR}


### PR DESCRIPTION
fixes #30 

Con esos cambios, el comportamiento te queda así:

**worker apagado + recurso CSV nuevo** → se ve **Pending**
**nunca validado y sin job** → se ve **Not validated**
**job con error** → se ve **Error**
**validación terminada** → se ve **Valid o Invalid** según corresponda.

## 

Esta PR mejora la consistencia y la visibilidad del flujo de validación asíncrona para recursos CSV.

El objetivo principal fue hacer que el estado de validación se vea en la interfaz desde el momento en que el job se encola, en lugar de esperar a que el worker empiece a procesarlo. Para eso, ahora el registro del job se crea en estado `QUEUED` antes de encolarse, y luego el worker actualiza ese mismo registro a lo largo del ciclo (`RUNNING` -> `FINISHED` / `ERROR`) en vez de crear uno nuevo al comenzar la ejecución.

Este cambio también ayuda a evitar jobs pendientes duplicados para un mismo recurso y mantiene más claro el historial del proceso, usando un único registro por ciclo de validación siempre que sea posible.

En la interfaz, además, el estado pendiente se actualizó para mostrar un spinner, de modo que sea más evidente que la validación sigue en curso, y las plantillas ahora muestran `Not validated` cuando todavía no existe un resultado de validación ni un job activo.


<img width="1360" height="860" alt="image" src="https://github.com/user-attachments/assets/cf7a294b-d016-4c23-abb1-142365bdc2ec" />
