### PR TITLE
Add tests for helpers, job isolation and pending job guard

### DIFF
--- a/ckanext/validate/tests/conftest.py
+++ b/ckanext/validate/tests/conftest.py
@@ -3,6 +3,10 @@ from ckanext.validate.model import ValidationJob
 from ckan.tests import factories
 
 
+def status_value(value):
+    return value.value if hasattr(value, "value") else value
+
+
 class DummyUploader:
     def __init__(self, path):
         self.path = str(path)

--- a/ckanext/validate/tests/test_helpers.py
+++ b/ckanext/validate/tests/test_helpers.py
@@ -1,7 +1,27 @@
+import pytest
+
 from ckanext.validate import helpers
 from ckanext.validate.model.validation import Validation
 from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
 from ckanext.validate.tests.conftest import status_value
+
+
+@pytest.mark.parametrize("job_status", list(JobStatus.error_statuses()))
+def test_get_resource_validation_state_returns_error_for_any_error_job_status(job_status):
+    resource_id = f"res-error-{job_status.value}"
+
+    ValidationJob.create(resource_id=resource_id, status=job_status)
+
+    assert helpers.get_resource_validation_state({"id": resource_id}) == "error"
+
+
+@pytest.mark.parametrize("job_status", list(JobStatus.pending_statuses()))
+def test_get_resource_validation_state_returns_pending_for_any_pending_job_status(job_status):
+    resource_id = f"res-pending-{job_status.value}"
+
+    ValidationJob.create(resource_id=resource_id, status=job_status)
+
+    assert helpers.get_resource_validation_state({"id": resource_id}) == "pending"
 
 
 def test_get_resource_validation_job_status_returns_none_without_resource():

--- a/ckanext/validate/tests/test_helpers.py
+++ b/ckanext/validate/tests/test_helpers.py
@@ -1,0 +1,71 @@
+from ckanext.validate import helpers
+from ckanext.validate.model.validation import Validation
+from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
+from ckanext.validate.tests.conftest import status_value
+
+
+def test_get_resource_validation_job_status_returns_none_without_resource():
+    assert helpers.get_resource_validation_job_status(None) is None
+    assert helpers.get_resource_validation_job_status({}) is None
+    assert helpers.get_resource_validation_job_status({"name": "no-id"}) is None
+
+
+def test_get_resource_validation_state_prefers_validation_success_over_pending_job():
+    resource_id = "res-success-over-pending"
+
+    Validation.create(
+        resource_id=resource_id,
+        status="success",
+        error_count=0,
+        errors=[],
+    )
+    ValidationJob.create(resource_id=resource_id, status=JobStatus.QUEUED)
+
+    assert helpers.get_resource_validation_state({"id": resource_id}) == "success"
+
+
+def test_get_resource_validation_state_prefers_validation_failure_over_running_job():
+    resource_id = "res-failure-over-running"
+
+    Validation.create(
+        resource_id=resource_id,
+        status="failure",
+        error_count=2,
+        errors=[{"message": "bad row"}],
+    )
+    ValidationJob.create(resource_id=resource_id, status=JobStatus.RUNNING)
+
+    assert helpers.get_resource_validation_state({"id": resource_id}) == "failure"
+
+
+def test_get_resource_validation_state_returns_pending_when_no_validation_and_job_is_pending():
+    resource_id = "res-pending"
+
+    ValidationJob.create(resource_id=resource_id, status=JobStatus.QUEUED)
+
+    assert helpers.get_resource_validation_state({"id": resource_id}) == "pending"
+
+
+def test_get_resource_validation_state_returns_error_when_no_validation_and_job_is_error():
+    resource_id = "res-error"
+
+    ValidationJob.create(resource_id=resource_id, status=JobStatus.ERROR)
+
+    assert helpers.get_resource_validation_state({"id": resource_id}) == "error"
+
+
+def test_get_resource_validation_state_returns_none_when_no_validation_or_job():
+    assert helpers.get_resource_validation_state(None) is None
+    assert helpers.get_resource_validation_state({}) is None
+    assert helpers.get_resource_validation_state({"id": "missing-resource"}) is None
+
+
+def test_get_resource_validation_job_status_returns_latest_job_status():
+    resource_id = "res-latest-job-status"
+
+    ValidationJob.create(resource_id=resource_id, status=JobStatus.ERROR)
+    ValidationJob.create(resource_id=resource_id, status=JobStatus.RUNNING)
+
+    status = helpers.get_resource_validation_job_status({"id": resource_id})
+
+    assert status_value(status) == "running"

--- a/ckanext/validate/tests/test_jobs.py
+++ b/ckanext/validate/tests/test_jobs.py
@@ -1,7 +1,93 @@
+import datetime
+
 from types import SimpleNamespace
 
 from ckanext.validate import jobs
-from ckanext.validate.model.validation_jobs import JobStatus
+from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
+from ckanext.validate.tests.conftest import status_value
+
+
+def test_run_resource_validation_job_updates_only_the_target_job_record(monkeypatch):
+    resource_id = "res-target-job-only"
+
+    older_job = ValidationJob.create(resource_id=resource_id, status=JobStatus.ERROR)
+    target_job = ValidationJob.create(resource_id=resource_id, status=JobStatus.QUEUED)
+
+    older_job.create_timestamp = datetime.datetime(2026, 1, 1, 12, 0, 0)
+    older_job.commit()
+
+    target_job.create_timestamp = datetime.datetime(2026, 1, 1, 12, 1, 0)
+    target_job.commit()
+
+    def fake_get_site_user(context, data_dict):
+        assert context == {"ignore_auth": True}
+        assert data_dict == {}
+        return {"name": "site-user"}
+
+    def fake_resource_validate(context, data_dict):
+        assert context == {"ignore_auth": True, "user": "site-user"}
+        assert data_dict == {"id": resource_id}
+        return {"id": resource_id}
+
+    def fake_get_action(name):
+        if name == "get_site_user":
+            return fake_get_site_user
+        if name == "resource_validate":
+            return fake_resource_validate
+        raise AssertionError(f"Unexpected action requested: {name}")
+
+    monkeypatch.setattr(jobs.toolkit, "get_action", fake_get_action)
+
+    jobs.run_resource_validation_job(resource_id, job_id=target_job.id)
+
+    refreshed_older_job = ValidationJob.get(older_job.id)
+    refreshed_target_job = ValidationJob.get(target_job.id)
+
+    assert status_value(refreshed_older_job.status) == "error"
+    assert refreshed_older_job.finish_timestamp is None
+
+    assert status_value(refreshed_target_job.status) == "finished"
+    assert refreshed_target_job.finish_timestamp is not None
+
+
+def test_run_resource_validation_job_marks_only_target_job_as_error(monkeypatch):
+    resource_id = "res-target-job-error-only"
+
+    older_job = ValidationJob.create(resource_id=resource_id, status=JobStatus.FINISHED)
+    target_job = ValidationJob.create(resource_id=resource_id, status=JobStatus.QUEUED)
+
+    older_job.create_timestamp = datetime.datetime(2026, 1, 1, 13, 0, 0)
+    older_job.finish_timestamp = datetime.datetime(2026, 1, 1, 13, 0, 5)
+    older_job.commit()
+
+    target_job.create_timestamp = datetime.datetime(2026, 1, 1, 13, 1, 0)
+    target_job.commit()
+
+    def fake_get_site_user(context, data_dict):
+        return {"name": "site-user"}
+
+    def fake_resource_validate(context, data_dict):
+        raise RuntimeError("boom")
+
+    def fake_get_action(name):
+        if name == "get_site_user":
+            return fake_get_site_user
+        if name == "resource_validate":
+            return fake_resource_validate
+        raise AssertionError(f"Unexpected action requested: {name}")
+
+    monkeypatch.setattr(jobs.toolkit, "get_action", fake_get_action)
+
+    jobs.run_resource_validation_job(resource_id, job_id=target_job.id)
+
+    refreshed_older_job = ValidationJob.get(older_job.id)
+    refreshed_target_job = ValidationJob.get(target_job.id)
+
+    assert status_value(refreshed_older_job.status) == "finished"
+    assert refreshed_older_job.finish_timestamp is not None
+
+    assert status_value(refreshed_target_job.status) == "error"
+    assert refreshed_target_job.finish_timestamp is not None
 
 
 def test_run_resource_validation_job_calls_resource_validate_with_site_user(monkeypatch):

--- a/ckanext/validate/tests/test_resource_hooks.py
+++ b/ckanext/validate/tests/test_resource_hooks.py
@@ -4,7 +4,8 @@ from types import SimpleNamespace
 
 from ckanext.validate import jobs
 from ckanext.validate import resource_hooks
-from ckanext.validate.model.validation_jobs import JobStatus
+from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
+from ckanext.validate.tests.conftest import status_value
 
 
 def test_enqueue_resource_validation_job_creates_db_job_and_enqueues_with_job_id_arg(monkeypatch):
@@ -177,3 +178,33 @@ def test_enqueue_resource_validation_job_skips_when_latest_job_is_pending(
 
     assert result is None
     assert calls == {"create": False, "enqueue": False}
+
+
+def test_enqueue_resource_validation_job_marks_created_job_as_error_in_db_when_enqueue_fails(
+    monkeypatch,
+):
+    created_job = ValidationJob.create(resource_id="res-enqueue-db-error", status="queued")
+
+    monkeypatch.setattr(
+        resource_hooks.ValidationJob,
+        "get_latest_job_status_for_resource",
+        lambda resource_id: None,
+    )
+    monkeypatch.setattr(
+        resource_hooks.ValidationJob,
+        "create",
+        lambda resource_id, status: SimpleNamespace(id=created_job.id),
+    )
+
+    def fake_enqueue_job(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(resource_hooks.toolkit, "enqueue_job", fake_enqueue_job)
+
+    result = resource_hooks.enqueue_resource_validation_job("res-enqueue-db-error")
+
+    refreshed = ValidationJob.get(created_job.id)
+
+    assert result is None
+    assert status_value(refreshed.status) == "error"
+    assert refreshed.finish_timestamp is not None

--- a/ckanext/validate/tests/test_resource_hooks.py
+++ b/ckanext/validate/tests/test_resource_hooks.py
@@ -1,3 +1,5 @@
+import pytest
+
 from types import SimpleNamespace
 
 from ckanext.validate import jobs
@@ -148,3 +150,30 @@ def test_enqueue_resource_validation_job_returns_none_when_enqueue_fails(monkeyp
 
     assert resource_hooks.enqueue_resource_validation_job("res-1") is None
     assert updated == {"job_id": 1, "status": JobStatus.ERROR}
+
+
+@pytest.mark.parametrize("pending_status", list(JobStatus.pending_statuses()))
+def test_enqueue_resource_validation_job_skips_when_latest_job_is_pending(
+    monkeypatch, pending_status
+):
+    calls = {"create": False, "enqueue": False}
+
+    monkeypatch.setattr(
+        resource_hooks.ValidationJob,
+        "get_latest_job_status_for_resource",
+        lambda resource_id: pending_status,
+    )
+
+    def fake_create(*args, **kwargs):
+        calls["create"] = True
+
+    def fake_enqueue_job(*args, **kwargs):
+        calls["enqueue"] = True
+
+    monkeypatch.setattr(resource_hooks.ValidationJob, "create", fake_create)
+    monkeypatch.setattr(resource_hooks.toolkit, "enqueue_job", fake_enqueue_job)
+
+    result = resource_hooks.enqueue_resource_validation_job("res-pending")
+
+    assert result is None
+    assert calls == {"create": False, "enqueue": False}

--- a/ckanext/validate/tests/test_validation_jobs.py
+++ b/ckanext/validate/tests/test_validation_jobs.py
@@ -1,0 +1,85 @@
+import datetime
+
+from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
+from ckanext.validate.tests.conftest import status_value
+
+
+def test_validation_job_create_stores_status_as_string():
+    job = ValidationJob.create(resource_id="res-create-string", status=JobStatus.QUEUED)
+
+    refreshed = ValidationJob.get(job.id)
+
+    assert status_value(refreshed.status) == "queued"
+    assert refreshed.finish_timestamp is None
+
+
+def test_validation_job_update_by_id_sets_finish_timestamp_for_finished():
+    job = ValidationJob.create(resource_id="res-finished-ts", status=JobStatus.QUEUED)
+
+    assert job.finish_timestamp is None
+
+    ValidationJob.update_by_id(job.id, JobStatus.FINISHED)
+
+    refreshed = ValidationJob.get(job.id)
+    assert status_value(refreshed.status) == "finished"
+    assert refreshed.finish_timestamp is not None
+
+
+def test_validation_job_update_by_id_sets_finish_timestamp_for_error():
+    job = ValidationJob.create(resource_id="res-error-ts", status=JobStatus.QUEUED)
+
+    assert job.finish_timestamp is None
+
+    ValidationJob.update_by_id(job.id, JobStatus.ERROR)
+
+    refreshed = ValidationJob.get(job.id)
+    assert status_value(refreshed.status) == "error"
+    assert refreshed.finish_timestamp is not None
+
+
+def test_validation_job_update_by_id_does_not_set_finish_timestamp_for_running():
+    job = ValidationJob.create(resource_id="res-running-ts", status=JobStatus.QUEUED)
+
+    assert job.finish_timestamp is None
+
+    ValidationJob.update_by_id(job.id, JobStatus.RUNNING)
+
+    refreshed = ValidationJob.get(job.id)
+    assert status_value(refreshed.status) == "running"
+    assert refreshed.finish_timestamp is None
+
+
+def test_get_latest_job_for_resource_returns_most_recent_job():
+    resource_id = "res-latest-job"
+
+    older = ValidationJob.create(resource_id=resource_id, status=JobStatus.QUEUED)
+    newer = ValidationJob.create(resource_id=resource_id, status=JobStatus.RUNNING)
+
+    older.create_timestamp = datetime.datetime(2026, 1, 1, 10, 0, 0)
+    older.commit()
+
+    newer.create_timestamp = datetime.datetime(2026, 1, 1, 10, 1, 0)
+    newer.commit()
+
+    latest = ValidationJob.get_latest_job_for_resource(resource_id)
+
+    assert latest is not None
+    assert latest.id == newer.id
+    assert status_value(latest.status) == "running"
+
+
+def test_get_latest_job_status_for_resource_returns_status_of_most_recent_job():
+    resource_id = "res-latest-status"
+
+    older = ValidationJob.create(resource_id=resource_id, status=JobStatus.ERROR)
+    newer = ValidationJob.create(resource_id=resource_id, status=JobStatus.FINISHED)
+
+    older.create_timestamp = datetime.datetime(2026, 1, 1, 11, 0, 0)
+    older.commit()
+
+    newer.create_timestamp = datetime.datetime(2026, 1, 1, 11, 1, 0)
+    newer.commit()
+
+    latest_status = ValidationJob.get_latest_job_status_for_resource(resource_id)
+
+    assert status_value(latest_status) == "finished"


### PR DESCRIPTION
### Qué se agregó

- Se agregó `test_helpers.py` con 7 tests que cubren:
  - `get_resource_validation_state()`
  - `get_resource_validation_job_status()`
  - la prioridad del resultado de validación persistido por sobre el estado del job
  - el comportamiento de fallback a `pending` / `error` cuando no existe un resultado de validación
  - casos borde con recurso faltante o sin ID

- Se agregaron 2 tests en `test_jobs.py` para verificar que:
  - `run_resource_validation_job()` actualiza únicamente el registro del job objetivo usando `job_id`
  - otros jobs del mismo recurso no se modifican
  - tanto el camino exitoso como el de error preservan el aislamiento entre jobs

- Se agregó un test parametrizado en `test_resource_hooks.py` para verificar que:
  - `enqueue_resource_validation_job()` no crea ni encola un nuevo job
    cuando el último job del recurso ya se encuentra en estado pendiente

- Se movió el helper `status_value` a `conftest.py` para evitar duplicación entre módulos de test

### Por qué

Estos tests van más allá de cubrir solo el flujo base y protegen específicamente el comportamiento introducido en esta rama:

- asegurar que un job no sobrescriba a otro
- asegurar que se actualice el registro de job correcto
- evitar jobs duplicados cuando ya existe uno pendiente
- asegurar que los helpers resuelvan correctamente el estado que se muestra a los usuarios