### PR TITLE
small fixes

### DIFF
--- a/ckanext/validate/actions/action.py
+++ b/ckanext/validate/actions/action.py
@@ -5,9 +5,10 @@ from ckan.lib import uploader
 
 import ckan.plugins.toolkit as toolkit
 
-from ckanext.validate.helpers import collect_report_errors
+from ckanext.validate.helpers import collect_report_errors, normalize_format
 from ckanext.validate.model import Validation
 from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
+from ckanext.validate.resource_hooks import is_csv_resource
 
 
 log = logging.getLogger(__name__)
@@ -26,14 +27,13 @@ def resource_validate(context, data_dict):
     toolkit.check_access("resource_update", context, {"id": resource_id})
     resource = toolkit.get_action("resource_show")(context, {"id": resource_id})
 
-    fmt = (resource.get("format") or "").upper()
-    if fmt != "CSV":
+    if not is_csv_resource(resource):
         raise toolkit.ValidationError(
             {"format": [toolkit._("Only CSV resources can be validated.")]}
         )
 
     is_uploaded = resource.get("url_type") == "upload"
-    fmt_lower = (resource.get("format") or "").lower()
+    fmt_lower = normalize_format(resource)
     if is_uploaded:
         # TODO: Refactor to new file API when migrating to CKAN 2.12.
         upload = uploader.get_resource_uploader(resource)

--- a/ckanext/validate/blueprints/resource.py
+++ b/ckanext/validate/blueprints/resource.py
@@ -94,7 +94,8 @@ def validate(package_id, resource_id):
 
 
 @validate_test_file_blueprint.route("/ckan-admin/testfile", methods=["GET", "POST"])
-def test_file():
+def validate_test_file_view():
+    """View to validate a test CSV file uploaded manually."""
     if not getattr(toolkit.current_user, "sysadmin", False):
         base.abort(403, toolkit._("Need to be system administrator to administer"))
 

--- a/ckanext/validate/blueprints/resource.py
+++ b/ckanext/validate/blueprints/resource.py
@@ -123,6 +123,7 @@ def test_file():
             )
 
         tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv")
+        os.close(tmp_fd)
         try:
             uploaded_file.save(tmp_path)
 
@@ -146,7 +147,6 @@ def test_file():
         finally:
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)
-            os.close(tmp_fd)  # TODO: check!
             success = True
 
     return base.render(

--- a/ckanext/validate/blueprints/resource.py
+++ b/ckanext/validate/blueprints/resource.py
@@ -18,7 +18,7 @@ resource_validate_blueprint = Blueprint(
 )
 
 validate_test_file_blueprint = Blueprint(
-    "validate_test_file", __name__, url_prefix="/validate"
+    "validate_test_file", __name__
 )
 
 
@@ -91,11 +91,6 @@ def validate(package_id, resource_id):
             "error_row_limit": h.MAX_ERROR_ROWS_PER_GROUP,
         },
     )
-
-
-validate_test_file_blueprint = Blueprint(
-    "validate_test_file", __name__
-)
 
 
 @validate_test_file_blueprint.route("/ckan-admin/testfile", methods=["GET", "POST"])

--- a/ckanext/validate/helpers.py
+++ b/ckanext/validate/helpers.py
@@ -261,3 +261,8 @@ def format_timestamp_for_display(value):
             return value
 
     return value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def normalize_format(resource_dict):
+    """Return the resource format in lowercase, or empty string."""
+    return (resource_dict.get("format") or "").strip().lower()

--- a/ckanext/validate/helpers.py
+++ b/ckanext/validate/helpers.py
@@ -113,6 +113,12 @@ def _preview_for_blank_label(items):
 
 
 def _preview_for_blank_row(items):
+    """
+    Generate a preview for blank-row errors.
+
+    Cells are intentionally blanked out to visually indicate a blank row in the
+    preview, even if the underlying data item contains partial values.
+    """
     max_columns = max(
         6,
         max((len(item["labels"]) for item in items), default=0),

--- a/ckanext/validate/helpers.py
+++ b/ckanext/validate/helpers.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 from collections import OrderedDict
 
@@ -256,7 +256,7 @@ def format_timestamp_for_display(value):
 
     if isinstance(value, str):
         try:
-            value = datetime.datetime.fromisoformat(value)
+            value = datetime.fromisoformat(value)
         except ValueError:
             return value
 

--- a/ckanext/validate/model/validation.py
+++ b/ckanext/validate/model/validation.py
@@ -52,11 +52,11 @@ class Validation(toolkit.BaseModel, ActiveRecordMixin):
 
     @classmethod
     def get_resource_status(cls, resource_id):
+        """Return the most recent validation status for a resource, or None."""
         record = cls.get_latest(resource_id)
         if record:
             return record.status
-        else:
-            return None
+        return None
 
     def as_dict(self):
         return {

--- a/ckanext/validate/model/validation.py
+++ b/ckanext/validate/model/validation.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Column, DateTime, Index, Integer, UnicodeText
 
@@ -18,7 +18,7 @@ class Validation(toolkit.BaseModel, ActiveRecordMixin):
     status = Column(UnicodeText, nullable=False)
     error_count = Column(Integer, nullable=False, default=0)
     errors = Column(JsonDictType)
-    created = Column(DateTime, nullable=False, default=datetime.datetime.utcnow)
+    created = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
 
     __table_args__ = (
         Index("ix_resource_validation_resource_id_created", "resource_id", "created"),

--- a/ckanext/validate/model/validation_jobs.py
+++ b/ckanext/validate/model/validation_jobs.py
@@ -85,13 +85,6 @@ class ValidationJob(toolkit.BaseModel, ActiveRecordMixin):
         return Session.query(cls).filter(cls.id == job_id).first()
 
     @classmethod
-    def update(cls, resource_id, status):
-        record = cls.get_latest_job_for_resource(resource_id)
-        if not record:
-            raise ValueError(f"No existing job found for resource_id {resource_id}")
-        return cls.update_by_id(record.id, status)
-
-    @classmethod
     def update_by_id(cls, job_id, status):
         record = cls.get(job_id)
         if not record:

--- a/ckanext/validate/model/validation_jobs.py
+++ b/ckanext/validate/model/validation_jobs.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 import enum
 import logging
 
@@ -58,7 +58,7 @@ class ValidationJob(toolkit.BaseModel, ActiveRecordMixin):
     id = Column(Integer, primary_key=True, autoincrement=True)
     resource_id = Column(UnicodeText, nullable=False)
     status = Column(UnicodeText, nullable=False)
-    create_timestamp = Column(DateTime, nullable=False, default=datetime.datetime.utcnow)
+    create_timestamp = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
     finish_timestamp = Column(DateTime, nullable=True)
 
     __table_args__ = (
@@ -99,7 +99,7 @@ class ValidationJob(toolkit.BaseModel, ActiveRecordMixin):
 
         record.status = status.value if isinstance(status, JobStatus) else status
         if status in JobStatus.terminal_statuses():
-            record.finish_timestamp = datetime.datetime.utcnow()
+            record.finish_timestamp = datetime.now(timezone.utc)
 
         record.commit()
         log.info(

--- a/ckanext/validate/model/validation_jobs.py
+++ b/ckanext/validate/model/validation_jobs.py
@@ -135,6 +135,7 @@ class ValidationJob(toolkit.BaseModel, ActiveRecordMixin):
 
     @classmethod
     def get_latest_job_status_for_resource(cls, resource_id):
+        """Return the most recent validation job status for a resource, or None."""
         record = cls.get_latest_job_for_resource(resource_id)
         if record:
             return record.status

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -4,13 +4,13 @@ import ckan.plugins.toolkit as toolkit
 
 from ckanext.validate import jobs
 from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
+from ckanext.validate.helpers import normalize_format
 
 log = logging.getLogger(__name__)
 
 
 def is_csv_resource(resource_dict):
-    fmt = (resource_dict.get("format") or "").strip().lower()
-    return fmt == "csv"
+    return normalize_format(resource_dict) == "csv"
 
 
 def is_resource_eligible_for_auto_validation(resource_dict):

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -58,6 +58,9 @@ def enqueue_resource_validation_job(resource_id):
 
 
 def handle_resource_change(resource_dict):
+    """
+    Handles resource changes by triggering validation if eligible.
+    """
     if not is_resource_eligible_for_auto_validation(resource_dict):
         log.debug(
             "Skipping auto-validation flow for resource %s "
@@ -67,10 +70,10 @@ def handle_resource_change(resource_dict):
             resource_dict.get("state") if resource_dict else None,
             resource_dict.get("url_type") if resource_dict else None,
         )
-        return False
+        return  # Returns None
 
     resource_id = resource_dict["id"]
     enqueue_resource_validation_job(resource_id)
 
     log.info("Validation job enqueued for resource %s", resource_id)
-    return True
+    # Returns None implicitly

--- a/ckanext/validate/templates/admin/base.html
+++ b/ckanext/validate/templates/admin/base.html
@@ -2,7 +2,7 @@
 
 {% block content_primary_nav %}
   {{ super() }}
-  {{ h.build_nav_icon('validate_test_file.test_file', _('Validate File'), icon='check-circle') }}
+  {{ h.build_nav_icon('validate_test_file.validate_test_file_view', _('Validate File'), icon='check-circle') }}
   {{ h.build_nav_icon('validate_admin.validation_jobs', _('Validation Jobs'), icon='tasks') }}
 {% endblock %}
 

--- a/ckanext/validate/tests/test_plugin.py
+++ b/ckanext/validate/tests/test_plugin.py
@@ -53,7 +53,6 @@ from ckan.plugins import plugin_loaded
 from ckanext.validate import resource_hooks
 from ckanext.validate.actions import action as validate_action
 from ckanext.validate.auth import validation as validate_auth
-from ckanext.validate.blueprints.resource import validate_test_file_blueprint
 from ckanext.validate.blueprints import resource as validate_resource
 from ckanext.validate.blueprints import admin as validate_admin
 from ckanext.validate.plugin import ValidatePlugin
@@ -72,7 +71,7 @@ def test_plugin_registers_expected_blueprint():
 
     assert blueprints == [
         validate_resource.resource_validate_blueprint,
-        validate_test_file_blueprint,
+        validate_resource.validate_test_file_blueprint,
         validate_admin.validation_jobs_blueprint,
     ]
 
@@ -161,6 +160,12 @@ def test_plugin_registers_expected_helpers():
 
 
 def test_plugin_delete_hooks_are_noops():
+    """
+    Verify that delete hooks are no-ops.
+    This ensures we haven't accidentally overridden before_resource_delete
+    or after_resource_delete, since our extension doesn't require cleanup
+    logic when deleting resources.
+    """
     plugin = ValidatePlugin()
 
     assert plugin.before_resource_delete({}, {"id": "res-6"}, [{"id": "res-6"}]) is None

--- a/ckanext/validate/tests/test_resource_hooks.py
+++ b/ckanext/validate/tests/test_resource_hooks.py
@@ -66,7 +66,7 @@ def test_handle_resource_change_enqueues_job_for_eligible_resource(monkeypatch):
 
     result = resource_hooks.handle_resource_change(resource)
 
-    assert result is True
+    assert result is None
     assert captured == {"resource_id": "res-2"}
 
 
@@ -92,7 +92,7 @@ def test_handle_resource_change_skips_non_csv(monkeypatch):
 
     result = resource_hooks.handle_resource_change(resource)
 
-    assert result is False
+    assert result is None
     assert called == {"enqueue": False}
 
 
@@ -118,7 +118,7 @@ def test_handle_resource_change_skips_deleted_resource(monkeypatch):
 
     result = resource_hooks.handle_resource_change(resource)
 
-    assert result is False
+    assert result is None
     assert called == {"enqueue": False}
 
 


### PR DESCRIPTION
> En esta rama se aplicó una ronda de ajustes menores de mantenimiento y limpieza del plugin. Los commits corrigen duplicidades en blueprints y validaciones CSV, actualizan el uso de fechas a un formato compatible con Python 3.12, cierran correctamente un descriptor temporal para evitar fugas, simplifican métodos redundantes, renombran una vista para mayor claridad, aclaran tests y documentación interna (docstring), eliminan retornos no usados y quitan código muerto que ya no se utilizaba.

Se hizo un commit por cada punto requerido en  Fixes #43
