### PR TITLE
Fix Restricción del método de la API de acción validation_job_list

### DIFF
--- a/ckanext/validate/actions/action.py
+++ b/ckanext/validate/actions/action.py
@@ -107,6 +107,7 @@ def resource_validation_show(context, data_dict):
     return record.as_dict()
 
 
+@toolkit.side_effect_free
 def validation_job_list(context, data_dict):
     """Return a list of validation jobs.
 

--- a/ckanext/validate/tests/test_action.py
+++ b/ckanext/validate/tests/test_action.py
@@ -303,6 +303,12 @@ def test_validation_job_list_returns_all_jobs(make_validation_job):
     assert {r["status"] for r in result} == {"finished", "failed"}
 
 
+def test_validation_job_list_is_side_effect_free():
+    action = toolkit.get_action("validation_job_list")
+
+    assert hasattr(action, "side_effect_free") is True
+
+
 def test_validation_job_list_filters_by_status(make_validation_job):
     resource = factories.Resource(format="CSV")
 


### PR DESCRIPTION
Este PR marca validation_job_list como side_effect_free para que CKAN permita invocarla vía GET en la Action API. Antes, la endpoint era rechazada con “Please use POST method” antes de entrar a la lógica de la extensión. También se agrega una prueba de regresión para asegurar que la action quede registrada como de solo lectura.

Antes
<img width="793" height="234" alt="image" src="https://github.com/user-attachments/assets/2ea7fd25-0396-4654-958c-59df2c0a4849" />


Ahora
<img width="814" height="471" alt="image" src="https://github.com/user-attachments/assets/4fd490ce-3f93-4a36-be50-270a294622dd" />
