### PR TITLE
Clean jobs tab

### DIFF
--- a/ckanext/validate/blueprints/admin.py
+++ b/ckanext/validate/blueprints/admin.py
@@ -42,21 +42,38 @@ def validation_jobs():
         job_dict["finished"] = format_timestamp_for_display(job_dict.get("finished"))
         try:
             resource = resource_show(context, {"id": job_dict["resource_id"]})
-            job_dict["resource_name"] = resource.get("name") or resource.get("description") or job_dict["resource_id"]
+            job_dict["resource_name"] = (
+                resource.get("name")
+                or resource.get("description")
+                or job_dict["resource_id"]
+            )
             job_dict["resource_url"] = toolkit.url_for(
                 "resource.read",
                 id=resource["package_id"],
                 resource_id=job_dict["resource_id"],
             )
+            return job_dict
+
         except toolkit.ObjectNotFound:
-            job_dict["resource_name"] = job_dict["resource_id"]
-            job_dict["resource_url"] = None
-        return job_dict
+            deleted = ValidationJob.delete_for_resource(job_dict["resource_id"])
+            log.info(
+                "Removed %s orphan validation jobs for deleted resource %s",
+                deleted,
+                job_dict["resource_id"],
+            )
+            return None
+
+    enriched_jobs = []
+
+    for job in jobs:
+        enriched_job = _enrich(job.as_dict())
+        if enriched_job:
+            enriched_jobs.append(enriched_job)
 
     return base.render(
         "admin/validation_jobs.html",
         extra_vars={
-            "jobs": [_enrich(job.as_dict()) for job in jobs],
+            "jobs": enriched_jobs,
             "available_statuses": available_statuses,
             "selected_status": selected_status,
         },

--- a/ckanext/validate/blueprints/admin.py
+++ b/ckanext/validate/blueprints/admin.py
@@ -36,33 +36,32 @@ def validation_jobs():
 
     resource_show = toolkit.get_action("resource_show")
     context = {"ignore_auth": True}
-    orphan_resource_ids = set()
 
     def _enrich(job_dict):
         job_dict["created"] = format_timestamp_for_display(job_dict.get("created"))
         job_dict["finished"] = format_timestamp_for_display(job_dict.get("finished"))
-
         try:
             resource = resource_show(context, {"id": job_dict["resource_id"]})
-        except Exception:
-            orphan_resource_ids.add(job_dict["resource_id"])
+            job_dict["resource_name"] = (
+                resource.get("name")
+                or resource.get("description")
+                or job_dict["resource_id"]
+            )
+            job_dict["resource_url"] = toolkit.url_for(
+                "resource.read",
+                id=resource["package_id"],
+                resource_id=job_dict["resource_id"],
+            )
+            return job_dict
+
+        except toolkit.ObjectNotFound:
+            deleted = ValidationJob.delete_for_resource(job_dict["resource_id"])
             log.info(
-                "Found orphan validation job for deleted resource %s",
+                "Removed %s orphan validation jobs for deleted resource %s",
+                deleted,
                 job_dict["resource_id"],
             )
             return None
-
-        job_dict["resource_name"] = (
-            resource.get("name")
-            or resource.get("description")
-            or job_dict["resource_id"]
-        )
-        job_dict["resource_url"] = toolkit.url_for(
-            "resource.read",
-            id=resource["package_id"],
-            resource_id=job_dict["resource_id"],
-        )
-        return job_dict
 
     enriched_jobs = []
 
@@ -70,14 +69,6 @@ def validation_jobs():
         enriched_job = _enrich(job.as_dict())
         if enriched_job:
             enriched_jobs.append(enriched_job)
-
-    for resource_id in orphan_resource_ids:
-        deleted = ValidationJob.delete_for_resource(resource_id)
-        log.info(
-            "Removed %s orphan validation jobs for deleted resource %s",
-            deleted,
-            resource_id,
-        )
 
     return base.render(
         "admin/validation_jobs.html",

--- a/ckanext/validate/blueprints/admin.py
+++ b/ckanext/validate/blueprints/admin.py
@@ -36,32 +36,33 @@ def validation_jobs():
 
     resource_show = toolkit.get_action("resource_show")
     context = {"ignore_auth": True}
+    orphan_resource_ids = set()
 
     def _enrich(job_dict):
         job_dict["created"] = format_timestamp_for_display(job_dict.get("created"))
         job_dict["finished"] = format_timestamp_for_display(job_dict.get("finished"))
+
         try:
             resource = resource_show(context, {"id": job_dict["resource_id"]})
-            job_dict["resource_name"] = (
-                resource.get("name")
-                or resource.get("description")
-                or job_dict["resource_id"]
-            )
-            job_dict["resource_url"] = toolkit.url_for(
-                "resource.read",
-                id=resource["package_id"],
-                resource_id=job_dict["resource_id"],
-            )
-            return job_dict
-
-        except toolkit.ObjectNotFound:
-            deleted = ValidationJob.delete_for_resource(job_dict["resource_id"])
+        except Exception:
+            orphan_resource_ids.add(job_dict["resource_id"])
             log.info(
-                "Removed %s orphan validation jobs for deleted resource %s",
-                deleted,
+                "Found orphan validation job for deleted resource %s",
                 job_dict["resource_id"],
             )
             return None
+
+        job_dict["resource_name"] = (
+            resource.get("name")
+            or resource.get("description")
+            or job_dict["resource_id"]
+        )
+        job_dict["resource_url"] = toolkit.url_for(
+            "resource.read",
+            id=resource["package_id"],
+            resource_id=job_dict["resource_id"],
+        )
+        return job_dict
 
     enriched_jobs = []
 
@@ -69,6 +70,14 @@ def validation_jobs():
         enriched_job = _enrich(job.as_dict())
         if enriched_job:
             enriched_jobs.append(enriched_job)
+
+    for resource_id in orphan_resource_ids:
+        deleted = ValidationJob.delete_for_resource(resource_id)
+        log.info(
+            "Removed %s orphan validation jobs for deleted resource %s",
+            deleted,
+            resource_id,
+        )
 
     return base.render(
         "admin/validation_jobs.html",

--- a/ckanext/validate/model/validation_jobs.py
+++ b/ckanext/validate/model/validation_jobs.py
@@ -134,6 +134,18 @@ class ValidationJob(toolkit.BaseModel, ActiveRecordMixin):
             return record.status
         return None
 
+    @classmethod
+    def delete_for_resource(cls, resource_id):
+        """Delete all validation jobs for a resource and return deleted row count."""
+        deleted = Session.query(cls).filter(cls.resource_id == resource_id).delete()
+        Session.commit()
+        log.info(
+            "Deleted %s validation jobs for resource_id=%s",
+            deleted,
+            resource_id,
+        )
+        return deleted
+
     def as_dict(self):
         return {
             "id": self.id,

--- a/ckanext/validate/plugin.py
+++ b/ckanext/validate/plugin.py
@@ -75,6 +75,13 @@ class ValidatePlugin(plugins.SingletonPlugin, DefaultTranslation):
             log.debug("Resource file changed, triggering validation for resource %s", updated_resource.get("id"))
             resource_hooks.handle_resource_change(updated_resource)
 
+    def before_resource_delete(self, context, resource, resources):
+        log.info(
+            "Cleaning validation jobs before deleting resource %s",
+            resource.get("id") if resource else None,
+        )
+        resource_hooks.cleanup_resource_jobs(resource)
+
     # ITemplateHelpers
 
     def get_helpers(self):

--- a/ckanext/validate/resource_hooks.py
+++ b/ckanext/validate/resource_hooks.py
@@ -77,3 +77,17 @@ def handle_resource_change(resource_dict):
 
     log.info("Validation job enqueued for resource %s", resource_id)
     # Returns None implicitly
+
+
+def cleanup_resource_jobs(resource_dict):
+    """Remove all persisted validation jobs associated to a deleted resource."""
+    resource_id = resource_dict.get("id") if resource_dict else None
+    if not resource_id:
+        return
+
+    deleted = ValidationJob.delete_for_resource(resource_id)
+    log.info(
+        "Removed %s validation jobs after deleting resource %s",
+        deleted,
+        resource_id,
+    )

--- a/ckanext/validate/tests/test_plugin.py
+++ b/ckanext/validate/tests/test_plugin.py
@@ -159,14 +159,28 @@ def test_plugin_registers_expected_helpers():
     assert "get_resource_validation_job_status" in helpers
 
 
-def test_plugin_delete_hooks_are_noops():
-    """
-    Verify that delete hooks are no-ops.
-    This ensures we haven't accidentally overridden before_resource_delete
-    or after_resource_delete, since our extension doesn't require cleanup
-    logic when deleting resources.
-    """
+def test_plugin_before_resource_delete_delegates_cleanup_for_deleted_resource(monkeypatch):
+    captured = []
+
+    def fake_cleanup_resource_jobs(resource_dict):
+        captured.append(resource_dict)
+
+    monkeypatch.setattr(
+        resource_hooks,
+        "cleanup_resource_jobs",
+        fake_cleanup_resource_jobs,
+    )
+
     plugin = ValidatePlugin()
 
-    assert plugin.before_resource_delete({}, {"id": "res-6"}, [{"id": "res-6"}]) is None
-    assert plugin.after_resource_delete({}, [{"id": "res-6"}]) is None
+    deleted_resource = {"id": "res-6"}
+    remaining_resources = [{"id": "res-7"}]
+
+    result = plugin.before_resource_delete(
+        {},
+        deleted_resource,
+        remaining_resources,
+    )
+
+    assert result is None
+    assert captured == [deleted_resource]

--- a/ckanext/validate/tests/test_resource_hooks.py
+++ b/ckanext/validate/tests/test_resource_hooks.py
@@ -208,3 +208,32 @@ def test_enqueue_resource_validation_job_marks_created_job_as_error_in_db_when_e
     assert result is None
     assert status_value(refreshed.status) == "error"
     assert refreshed.finish_timestamp is not None
+
+
+def test_cleanup_resource_jobs_deletes_all_jobs_for_resource(monkeypatch):
+    captured = {}
+
+    def fake_delete_for_resource(resource_id):
+        captured["resource_id"] = resource_id
+        return 3
+
+    monkeypatch.setattr(resource_hooks.ValidationJob, "delete_for_resource", fake_delete_for_resource)
+
+    result = resource_hooks.cleanup_resource_jobs({"id": "res-delete-1"})
+
+    assert result is None
+    assert captured == {"resource_id": "res-delete-1"}
+
+
+def test_cleanup_resource_jobs_skips_when_resource_has_no_id(monkeypatch):
+    called = {"delete": False}
+
+    def fake_delete_for_resource(resource_id):
+        called["delete"] = True
+
+    monkeypatch.setattr(resource_hooks.ValidationJob, "delete_for_resource", fake_delete_for_resource)
+
+    result = resource_hooks.cleanup_resource_jobs({})
+
+    assert result is None
+    assert called == {"delete": False}

--- a/ckanext/validate/tests/test_resource_hooks.py
+++ b/ckanext/validate/tests/test_resource_hooks.py
@@ -1,6 +1,7 @@
-import pytest
-
 from types import SimpleNamespace
+
+import pytest
+from ckan.tests import factories, helpers
 
 from ckanext.validate import jobs
 from ckanext.validate import resource_hooks
@@ -210,30 +211,69 @@ def test_enqueue_resource_validation_job_marks_created_job_as_error_in_db_when_e
     assert refreshed.finish_timestamp is not None
 
 
-def test_cleanup_resource_jobs_deletes_all_jobs_for_resource(monkeypatch):
-    captured = {}
-
-    def fake_delete_for_resource(resource_id):
-        captured["resource_id"] = resource_id
-        return 3
-
-    monkeypatch.setattr(resource_hooks.ValidationJob, "delete_for_resource", fake_delete_for_resource)
-
-    result = resource_hooks.cleanup_resource_jobs({"id": "res-delete-1"})
-
-    assert result is None
-    assert captured == {"resource_id": "res-delete-1"}
-
-
-def test_cleanup_resource_jobs_skips_when_resource_has_no_id(monkeypatch):
+@pytest.mark.parametrize("resource", [None, {}])
+def test_cleanup_resource_jobs_skips_when_resource_has_no_id(monkeypatch, resource):
     called = {"delete": False}
 
     def fake_delete_for_resource(resource_id):
         called["delete"] = True
 
-    monkeypatch.setattr(resource_hooks.ValidationJob, "delete_for_resource", fake_delete_for_resource)
+    monkeypatch.setattr(
+        resource_hooks.ValidationJob,
+        "delete_for_resource",
+        fake_delete_for_resource,
+    )
 
-    result = resource_hooks.cleanup_resource_jobs({})
+    result = resource_hooks.cleanup_resource_jobs(resource)
 
     assert result is None
     assert called == {"delete": False}
+
+
+@pytest.mark.ckan_config("ckan.plugins", "validate")
+@pytest.mark.usefixtures("with_plugins")
+def test_resource_delete_action_removes_validation_jobs_for_deleted_resource(monkeypatch):
+    # Avoid auto-enqueueing validation jobs while creating resources in the test.
+    monkeypatch.setattr(
+        resource_hooks,
+        "handle_resource_change",
+        lambda *args, **kwargs: None,
+    )
+
+    sysadmin = factories.Sysadmin()
+    dataset = factories.Dataset()
+
+    resource = factories.Resource(
+        package_id=dataset["id"],
+        format="CSV",
+    )
+    other_resource = factories.Resource(
+        package_id=dataset["id"],
+        format="CSV",
+    )
+
+    job_a = ValidationJob.create(
+        resource_id=resource["id"],
+        status=JobStatus.QUEUED,
+    )
+    job_b = ValidationJob.create(
+        resource_id=resource["id"],
+        status=JobStatus.FINISHED,
+    )
+    other_job = ValidationJob.create(
+        resource_id=other_resource["id"],
+        status=JobStatus.QUEUED,
+    )
+
+    helpers.call_action(
+        "resource_delete",
+        context={"user": sysadmin["name"]},
+        id=resource["id"],
+    )
+
+    assert ValidationJob.get(job_a.id) is None
+    assert ValidationJob.get(job_b.id) is None
+    assert ValidationJob.get_latest_job_for_resource(resource["id"]) is None
+
+    # Sanity check: deleting one resource must not remove jobs from another resource.
+    assert ValidationJob.get(other_job.id) is not None

--- a/ckanext/validate/tests/test_validation_jobs.py
+++ b/ckanext/validate/tests/test_validation_jobs.py
@@ -83,3 +83,19 @@ def test_get_latest_job_status_for_resource_returns_status_of_most_recent_job():
     latest_status = ValidationJob.get_latest_job_status_for_resource(resource_id)
 
     assert status_value(latest_status) == "finished"
+
+
+def test_delete_for_resource_removes_only_matching_jobs():
+    target_resource_id = "res-delete-jobs-target"
+    other_resource_id = "res-delete-jobs-other"
+
+    target_a = ValidationJob.create(resource_id=target_resource_id, status=JobStatus.QUEUED)
+    target_b = ValidationJob.create(resource_id=target_resource_id, status=JobStatus.RUNNING)
+    other = ValidationJob.create(resource_id=other_resource_id, status=JobStatus.FINISHED)
+
+    deleted = ValidationJob.delete_for_resource(target_resource_id)
+
+    assert deleted == 2
+    assert ValidationJob.get(target_a.id) is None
+    assert ValidationJob.get(target_b.id) is None
+    assert ValidationJob.get(other.id) is not None


### PR DESCRIPTION
fixes #49 

Se limpia la tabla de jobs de validación cuando un recurso asociado es eliminado.

Antes, si un recurso CSV validado era borrado, el job quedaba listado en la vista de administración y se mostraba el `resource_id` sin link, generando registros huérfanos.

Ahora, mediante `before_resource_delete`, se eliminan los jobs persistidos para el recurso borrado. Además, la vista `/ckan-admin/validation-jobs` filtra y limpia jobs huérfanos si detecta que el recurso asociado ya no existe.

### Tests

Se agregan y actualizan tests para cubrir:

- Limpieza de jobs al borrar un recurso.
- Eliminación de jobs por `resource_id`.
- Casos donde el recurso no tiene `id`.
- Delegación correcta desde el plugin hacia `resource_hooks`.