### PR TITLE
Update context in validation_jobs to use current user for resource_show

### DIFF
--- a/ckanext/validate/blueprints/admin.py
+++ b/ckanext/validate/blueprints/admin.py
@@ -35,7 +35,7 @@ def validation_jobs():
     )
 
     resource_show = toolkit.get_action("resource_show")
-    context = {"ignore_auth": True}
+    context = {"user": toolkit.current_user.name}
 
     def _enrich(job_dict):
         job_dict["created"] = format_timestamp_for_display(job_dict.get("created"))

--- a/ckanext/validate/blueprints/admin.py
+++ b/ckanext/validate/blueprints/admin.py
@@ -35,9 +35,10 @@ def validation_jobs():
     )
 
     resource_show = toolkit.get_action("resource_show")
-    context = {"user": toolkit.current_user.name}
 
     def _enrich(job_dict):
+        context = {"user": toolkit.current_user.name}
+
         job_dict["created"] = format_timestamp_for_display(job_dict.get("created"))
         job_dict["finished"] = format_timestamp_for_display(job_dict.get("finished"))
         try:

--- a/ckanext/validate/tests/test_jobs.py
+++ b/ckanext/validate/tests/test_jobs.py
@@ -1,10 +1,12 @@
 import datetime
+import pytest
 
 from types import SimpleNamespace
 
 from ckanext.validate import jobs
 from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
 from ckanext.validate.tests.conftest import status_value
+from ckanext.validate.blueprints import admin
 
 
 def test_run_resource_validation_job_updates_only_the_target_job_record(monkeypatch):
@@ -202,4 +204,71 @@ def test_run_resource_validation_job_returns_early_when_job_record_does_not_exis
     assert resource_validate_called == []
     assert state_calls == [
         ("update_by_id", 321, JobStatus.RUNNING),
+    ]
+
+
+@pytest.mark.ckan_config("ckan.plugins", "validate")
+@pytest.mark.usefixtures("with_plugins")
+def test_validation_jobs_uses_fresh_context_for_each_resource(app, monkeypatch):
+    """Ensure each resource_show call gets a fresh context.
+
+    CKAN actions may mutate the context during execution, so the admin view
+    must not reuse the same context across consecutive resource_show calls.
+    """
+    job_1 = ValidationJob.create(
+        resource_id="resource-1",
+        status=JobStatus.FINISHED,
+    )
+    job_2 = ValidationJob.create(
+        resource_id="resource-2",
+        status=JobStatus.FINISHED,
+    )
+
+    monkeypatch.setattr(
+        admin.toolkit,
+        "current_user",
+        SimpleNamespace(name="sysadmin", sysadmin=True),
+    )
+    monkeypatch.setattr(
+        admin.ValidationJob,
+        "get_all",
+        lambda status=None, limit=100: [job_1, job_2],
+    )
+    monkeypatch.setattr(
+        admin.toolkit,
+        "url_for",
+        lambda *args, **kwargs: f"/resource/{kwargs['resource_id']}",
+    )
+
+    contexts = []
+
+    def fake_resource_show(context, data_dict):
+        contexts.append(dict(context))
+
+        # Simulate CKAN actions mutating the context during execution.
+        context["dirty"] = True
+
+        return {
+            "id": data_dict["id"],
+            "name": data_dict["id"],
+            "package_id": "dataset-1",
+        }
+
+    def fake_get_action(action_name):
+        assert action_name == "resource_show"
+        return fake_resource_show
+
+    monkeypatch.setattr(admin.toolkit, "get_action", fake_get_action)
+    monkeypatch.setattr(
+        admin.base,
+        "render",
+        lambda template, extra_vars: "ok",
+    )
+
+    response = app.get("/ckan-admin/validation-jobs")
+
+    assert response.status_code == 200
+    assert contexts == [
+        {"user": "sysadmin"},
+        {"user": "sysadmin"},
     ]

--- a/ckanext/validate/tests/test_jobs.py
+++ b/ckanext/validate/tests/test_jobs.py
@@ -1,12 +1,10 @@
 import datetime
-import pytest
 
 from types import SimpleNamespace
 
 from ckanext.validate import jobs
 from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
 from ckanext.validate.tests.conftest import status_value
-from ckanext.validate.blueprints import admin
 
 
 def test_run_resource_validation_job_updates_only_the_target_job_record(monkeypatch):
@@ -204,71 +202,4 @@ def test_run_resource_validation_job_returns_early_when_job_record_does_not_exis
     assert resource_validate_called == []
     assert state_calls == [
         ("update_by_id", 321, JobStatus.RUNNING),
-    ]
-
-
-@pytest.mark.ckan_config("ckan.plugins", "validate")
-@pytest.mark.usefixtures("with_plugins")
-def test_validation_jobs_uses_fresh_context_for_each_resource(app, monkeypatch):
-    """Ensure each resource_show call gets a fresh context.
-
-    CKAN actions may mutate the context during execution, so the admin view
-    must not reuse the same context across consecutive resource_show calls.
-    """
-    job_1 = ValidationJob.create(
-        resource_id="resource-1",
-        status=JobStatus.FINISHED,
-    )
-    job_2 = ValidationJob.create(
-        resource_id="resource-2",
-        status=JobStatus.FINISHED,
-    )
-
-    monkeypatch.setattr(
-        admin.toolkit,
-        "current_user",
-        SimpleNamespace(name="sysadmin", sysadmin=True),
-    )
-    monkeypatch.setattr(
-        admin.ValidationJob,
-        "get_all",
-        lambda status=None, limit=100: [job_1, job_2],
-    )
-    monkeypatch.setattr(
-        admin.toolkit,
-        "url_for",
-        lambda *args, **kwargs: f"/resource/{kwargs['resource_id']}",
-    )
-
-    contexts = []
-
-    def fake_resource_show(context, data_dict):
-        contexts.append(dict(context))
-
-        # Simulate CKAN actions mutating the context during execution.
-        context["dirty"] = True
-
-        return {
-            "id": data_dict["id"],
-            "name": data_dict["id"],
-            "package_id": "dataset-1",
-        }
-
-    def fake_get_action(action_name):
-        assert action_name == "resource_show"
-        return fake_resource_show
-
-    monkeypatch.setattr(admin.toolkit, "get_action", fake_get_action)
-    monkeypatch.setattr(
-        admin.base,
-        "render",
-        lambda template, extra_vars: "ok",
-    )
-
-    response = app.get("/ckan-admin/validation-jobs")
-
-    assert response.status_code == 200
-    assert contexts == [
-        {"user": "sysadmin"},
-        {"user": "sysadmin"},
     ]


### PR DESCRIPTION
fixes #59 

Se corrigió la llamada interna a `resource_show` en la vista administrativa de jobs de validación.

La vista estaba usando `ignore_auth=True`, lo que hacía que CKAN 2.11.5 detectara que la action `resource_show` no había ejecutado su función de autorización y generara el error:

`Action function resource_show did not call its auth function`

Como la página `/ckan-admin/validation-jobs` ya está restringida a usuarios sysadmin, se reemplazó ese contexto por uno basado en el usuario actual. De esta forma CKAN ejecuta el flujo normal de autorización y la vista puede cargar los recursos asociados a los jobs sin romper.