### PR TITLE
Add null value detection to resource validation

### DIFF
--- a/ckanext/validate/actions/action.py
+++ b/ckanext/validate/actions/action.py
@@ -66,8 +66,18 @@ def resource_validate(context, data_dict):
         resource_id, report.valid,
     )
 
-    status = "success" if report.valid else "failure"
     error_details = h.collect_report_errors(report)
+    invalid_null_errors = h.detect_invalid_null_values(source)
+
+    if invalid_null_errors:
+        log.info(
+            "Invalid null-like values found for resource %s: errors=%d",
+            resource_id,
+            len(invalid_null_errors),
+        )
+        error_details.extend(invalid_null_errors)
+
+    status = "success" if report.valid and not invalid_null_errors else "failure"
     error_count = len(error_details)
 
     Validation.create(

--- a/ckanext/validate/helpers.py
+++ b/ckanext/validate/helpers.py
@@ -1,6 +1,9 @@
+import csv
 from datetime import datetime
 
 from collections import OrderedDict
+from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 import ckan.plugins.toolkit as toolkit
 
@@ -9,6 +12,7 @@ from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
 
 
 MAX_ERROR_ROWS_PER_GROUP = 20
+INVALID_NULL_VALUES = {"null", "none"}
 
 
 def collect_report_errors(report):
@@ -290,3 +294,73 @@ def validation_error_message(error):
             messages.append(str(value))
 
     return "; ".join(messages) or str(error)
+
+
+def _is_invalid_null_value(value):
+    return str(value).strip().lower() in INVALID_NULL_VALUES
+
+
+def _source_to_local_path(source):
+    parsed = urlparse(source)
+
+    if parsed.scheme == "file":
+        return Path(unquote(parsed.path))
+
+    if not parsed.scheme:
+        return Path(source)
+
+    return None
+
+
+def detect_invalid_null_values(source):
+    path = _source_to_local_path(source)
+    if path is None:
+        return []
+
+    errors = []
+
+    with path.open(newline="", encoding="utf-8-sig", errors="replace") as csv_file:
+        sample = csv_file.read(4096)
+        csv_file.seek(0)
+
+        try:
+            dialect = csv.Sniffer().sniff(sample)
+        except csv.Error:
+            dialect = csv.excel
+
+        reader = csv.reader(csv_file, dialect=dialect)
+
+        try:
+            labels = next(reader)
+        except StopIteration:
+            return []
+
+        for row_number, cells in enumerate(reader, start=2):
+            for field_number, value in enumerate(cells, start=1):
+                if not _is_invalid_null_value(value):
+                    continue
+
+                field_name = (
+                    labels[field_number - 1]
+                    if field_number <= len(labels)
+                    else None
+                )
+
+                errors.append(
+                    {
+                        "type": "invalid-null-value",
+                        "title": toolkit._("Invalid null value"),
+                        "description": toolkit._(
+                            "The values 'null', 'NULL' and 'None' are not allowed."
+                        ),
+                        "message": toolkit._("Invalid null-like value found."),
+                        "rowNumber": row_number,
+                        "rowNumbers": [row_number],
+                        "fieldName": field_name,
+                        "fieldNumber": field_number,
+                        "cells": cells,
+                        "labels": labels,
+                    }
+                )
+
+    return errors

--- a/ckanext/validate/tests/test_action.py
+++ b/ckanext/validate/tests/test_action.py
@@ -365,3 +365,42 @@ def test_validation_job_list_returns_expected_fields(make_validation_job):
     assert set(job.keys()) == {"id", "resource_id", "status", "created", "finished"}
     assert job["resource_id"] == resource["id"]
     assert job["status"] == "finished"
+
+
+def test_resource_validate_marks_null_like_values_as_failure(tmp_path):
+    csv_file = tmp_path / "null-values.csv"
+    csv_file.write_text(
+        "name,observacion,empty_allowed\n"
+        "Alice,null,\n"
+        "Bob,   ,   \n"
+        "Carla,None,text\n"
+        "Dora,NULL,text\n",
+        encoding="utf-8",
+    )
+
+    resource = factories.Resource(
+        format="CSV",
+        url_type="",
+        url=csv_file.resolve().as_uri(),
+    )
+    sysadmin = factories.Sysadmin()
+
+    result = validate_action.resource_validate(
+        {"user": sysadmin["name"]}, {"id": resource["id"]}
+    )
+
+    assert result["id"] == resource["id"]
+
+    record = Validation.get_latest(resource["id"])
+    assert record is not None
+    assert record.status == "failure"
+
+    null_errors = [
+        error
+        for error in record.errors
+        if error.get("type") == "invalid-null-value"
+    ]
+
+    assert len(null_errors) == 3
+    assert {error["rowNumber"] for error in null_errors} == {2, 4, 5}
+    assert {error["fieldName"] for error in null_errors} == {"observacion"}


### PR DESCRIPTION
related  #69 
### Summary

Added a custom validation step to detect invalid null-like string values in CSV resources.

The validator now marks a resource as invalid when any cell contains values such as `null`, `NULL`, or `None`, while still allowing genuinely empty cells or cells with blank spaces.

### Why

Frictionless treats these values as regular strings, so CSV files containing textual null values could previously be marked as valid. This change prevents false positives and surfaces those values as validation errors with row and column details.

<img width="1395" height="862" alt="image" src="https://github.com/user-attachments/assets/bb0ac7aa-c197-4e21-8718-98a9660e6965" />
