### PR TITLE
fix error 500

### DIFF
--- a/ckanext/validate/blueprints/admin.py
+++ b/ckanext/validate/blueprints/admin.py
@@ -17,14 +17,13 @@ validation_jobs_blueprint = Blueprint(
 
 @validation_jobs_blueprint.route("/ckan-admin/validation-jobs", methods=["GET"])
 def validation_jobs():
+    context = {
+        "user": toolkit.current_user.name,
+        "auth_user_obj": toolkit.current_user,
+    }
+
     try:
-        toolkit.check_access(
-            "sysadmin",
-            {
-                "user": toolkit.current_user.name,
-                "auth_user_obj": toolkit.current_user,
-            },
-        )
+        toolkit.check_access("sysadmin", context)
     except toolkit.NotAuthorized:
         base.abort(403, toolkit._("Need to be system administrator to administer"))
 

--- a/ckanext/validate/blueprints/admin.py
+++ b/ckanext/validate/blueprints/admin.py
@@ -17,7 +17,15 @@ validation_jobs_blueprint = Blueprint(
 
 @validation_jobs_blueprint.route("/ckan-admin/validation-jobs", methods=["GET"])
 def validation_jobs():
-    if not getattr(toolkit.current_user, "sysadmin", False):
+    try:
+        toolkit.check_access(
+            "sysadmin",
+            {
+                "user": toolkit.current_user.name,
+                "auth_user_obj": toolkit.current_user,
+            },
+        )
+    except toolkit.NotAuthorized:
         base.abort(403, toolkit._("Need to be system administrator to administer"))
 
     available_statuses = [status.value for status in JobStatus]
@@ -37,10 +45,14 @@ def validation_jobs():
     resource_show = toolkit.get_action("resource_show")
 
     def _enrich(job_dict):
-        context = {"user": toolkit.current_user.name}
+        context = {
+            "user": toolkit.current_user.name,
+            "auth_user_obj": toolkit.current_user,
+        }
 
         job_dict["created"] = format_timestamp_for_display(job_dict.get("created"))
         job_dict["finished"] = format_timestamp_for_display(job_dict.get("finished"))
+
         try:
             resource = resource_show(context, {"id": job_dict["resource_id"]})
             job_dict["resource_name"] = (

--- a/ckanext/validate/blueprints/admin.py
+++ b/ckanext/validate/blueprints/admin.py
@@ -17,10 +17,7 @@ validation_jobs_blueprint = Blueprint(
 
 @validation_jobs_blueprint.route("/ckan-admin/validation-jobs", methods=["GET"])
 def validation_jobs():
-    context = {
-        "user": toolkit.current_user.name,
-        "auth_user_obj": toolkit.current_user,
-    }
+    context = {"user": toolkit.current_user.name}
 
     try:
         toolkit.check_access("sysadmin", context)
@@ -44,10 +41,7 @@ def validation_jobs():
     resource_show = toolkit.get_action("resource_show")
 
     def _enrich(job_dict):
-        context = {
-            "user": toolkit.current_user.name,
-            "auth_user_obj": toolkit.current_user,
-        }
+        context = {"user": toolkit.current_user.name}
 
         job_dict["created"] = format_timestamp_for_display(job_dict.get("created"))
         job_dict["finished"] = format_timestamp_for_display(job_dict.get("finished"))


### PR DESCRIPTION
fixes #57 

Updated the validation jobs admin view to use CKAN’s standard authorization flow via `toolkit.check_access("sysadmin", context)` and to pass a complete action context, including `auth_user_obj`, when calling `resource_show`. This avoids CKAN auth audit errors when rendering validation jobs.