### PR TITLE
Enhance error preview merging logic to handle multiple column errors …

### DIFF
--- a/ckanext/validate/blueprints/resource.py
+++ b/ckanext/validate/blueprints/resource.py
@@ -190,4 +190,3 @@ def validate_status(resource_id):
         "validate/snippets/validation_badge.html",
         extra_vars={"resource": resource}
             )
-

--- a/ckanext/validate/helpers.py
+++ b/ckanext/validate/helpers.py
@@ -149,26 +149,47 @@ def _preview_for_general_rows(items):
         max((item["field_number"] or 0 for item in items), default=0),
     )
 
-    rows = []
-    for item in items:
-        cells = []
-        raw_cells = item["cells"]
+    rows_by_key = OrderedDict()
 
-        for index in range(max_columns):
-            if index < len(raw_cells):
-                cells.append(raw_cells[index] or "")
+    for index, item in enumerate(items):
+        row_number = item["row_number"]
+
+        # Merge only real data rows. If row_number is None, keep the item
+        # separated to avoid collapsing structural/non-row errors together.
+        row_key = ("row", row_number) if row_number is not None else ("item", index)
+
+        raw_cells = item["cells"]
+        cells = []
+        for column_index in range(max_columns):
+            if column_index < len(raw_cells):
+                cells.append(raw_cells[column_index] or "")
             else:
                 cells.append("")
 
-        highlight_columns = []
-        if item["field_number"]:
-            highlight_columns = [item["field_number"]]
+        if row_key not in rows_by_key:
+            rows_by_key[row_key] = {
+                "row_number": row_number,
+                "cells": cells,
+                "highlight_columns": set(),
+            }
+        else:
+            # Keep the first row representation, but fill missing cells if a
+            # later error has more complete data for the same row.
+            existing_cells = rows_by_key[row_key]["cells"]
+            for column_index, cell in enumerate(cells):
+                if not existing_cells[column_index] and cell:
+                    existing_cells[column_index] = cell
 
+        if item["field_number"]:
+            rows_by_key[row_key]["highlight_columns"].add(item["field_number"])
+
+    rows = []
+    for row in rows_by_key.values():
         rows.append(
             {
-                "row_number": item["row_number"],
-                "cells": cells,
-                "highlight_columns": highlight_columns,
+                "row_number": row["row_number"],
+                "cells": row["cells"],
+                "highlight_columns": sorted(row["highlight_columns"]),
             }
         )
 

--- a/ckanext/validate/tests/test_helpers.py
+++ b/ckanext/validate/tests/test_helpers.py
@@ -4,6 +4,7 @@ from ckanext.validate import helpers
 from ckanext.validate.model.validation import Validation
 from ckanext.validate.model.validation_jobs import JobStatus, ValidationJob
 from ckanext.validate.tests.conftest import status_value
+from ckanext.validate import helpers as h
 
 
 @pytest.mark.parametrize("job_status", list(JobStatus.error_statuses()))
@@ -89,3 +90,40 @@ def test_get_resource_validation_job_status_returns_latest_job_status():
     status = helpers.get_resource_validation_job_status({"id": resource_id})
 
     assert status_value(status) == "running"
+
+
+def test_group_validation_errors_merges_preview_rows_with_multiple_column_errors():
+    errors = [
+        {
+            "type": "type-error",
+            "title": "Type Error",
+            "message": "Column 2 is invalid",
+            "rowNumber": 12,
+            "fieldNumber": 2,
+            "cells": ["501247-540", "bad", "501247", "also bad"],
+        },
+        {
+            "type": "type-error",
+            "title": "Type Error",
+            "message": "Column 4 is invalid",
+            "rowNumber": 12,
+            "fieldNumber": 4,
+            "cells": ["501247-540", "bad", "501247", "also bad"],
+        },
+        {
+            "type": "type-error",
+            "title": "Type Error",
+            "message": "Column 3 is invalid",
+            "rowNumber": 13,
+            "fieldNumber": 3,
+            "cells": ["501247-541", "ok", "bad", "ok"],
+        },
+    ]
+
+    groups = h.group_validation_errors(errors)
+
+    preview_rows = groups[0]["preview"]["rows"]
+
+    assert [row["row_number"] for row in preview_rows] == [12, 13]
+    assert preview_rows[0]["highlight_columns"] == [2, 4]
+    assert preview_rows[1]["highlight_columns"] == [3]


### PR DESCRIPTION
fixes #73 

Se ajustó la generación de la preview de errores para agrupar en una sola fila visual los errores que pertenecen al mismo rowNumber dentro del mismo tipo de error


<img width="1395" height="912" alt="image" src="https://github.com/user-attachments/assets/fd0ddb27-a350-40e7-b36e-00ff9306e185" />
