### PR TITLE
Update version 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ckanext-validate"
-version = "0.4.0"
+version = "0.5.2"
 description = "A Simple CKAN extension to validate tabular data."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This pull request updates the version number of the `ckanext-validate` project.

- Project version updated from `0.4.0` to `0.5.2` in `pyproject.toml` to reflect new changes.

Cambios de este tag: 

https://github.com/okfn/ckanext-validate/releases